### PR TITLE
提交 [Translate] Issue 即可排队，多篇按行写标题

### DIFF
--- a/.cursor/skills/translating-articles/SKILL.md
+++ b/.cursor/skills/translating-articles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: translating-articles
-description: Use when translating an English technical article into this repo from a URL, GitHub issue labeled translate, _inbox/*.source.md file, or a request to 翻译 / translate an article.
+description: Use when translating an English technical article into this repo from a URL pasted in Cursor, a GitHub [Translate] issue, _inbox/*.source.md, or a request to 翻译 / translate. Cursor-chat URLs must create a GitHub issue first.
 ---
 
 Follow `.github/skills/translating-articles/SKILL.md` exactly.

--- a/.github/ISSUE_TEMPLATE/translate-article.yml
+++ b/.github/ISSUE_TEMPLATE/translate-article.yml
@@ -1,30 +1,38 @@
-name: Translate article
-description: Submit one or more English article URLs for Chinese translation
+name: 翻译文章
+description: 提交一篇或多篇英文文章，自动抓取并排队翻译
 title: "[Translate] "
 labels: [translate]
 body:
   - type: markdown
     attributes:
       value: |
-        Paste the public article link(s). A GitHub Action will fetch the page into `_inbox/`, then Copilot or Cursor can translate it using the `article-translator` agent / translating-articles skill.
+        一篇文章：填原文链接，可选填中文标题。
+        多篇文章：不要共用一个标题，在「更多文章」里每行一篇，写成 `链接` 或 `链接 | 中文标题`。
+        提交后 GitHub Action 会抓原文并开 inbox PR；若仓库配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。
   - type: input
     id: url
     attributes:
-      label: Article URL
-      description: The English article to translate
-      placeholder: https://medium.com/...
+      label: 原文链接
+      description: 要翻译的英文文章
+      placeholder: https://example.com/article
     validations:
       required: true
+  - type: input
+    id: title_zh
+    attributes:
+      label: 中文标题
+      description: 只作用于上面这一篇。不填则用 Issue 标题（去掉 [Translate]）或原文标题。
+      placeholder: AI 芯片架构
   - type: textarea
     id: extra_urls
     attributes:
-      label: Additional URLs
-      description: Optional. One URL per line if you have more than one article today.
+      label: 更多文章
+      description: 可选。每行一篇，不要把多篇的标题写进上面的「中文标题」。
       placeholder: |
-        https://example.com/article-two
+        https://example.com/article-two | 第二篇中文标题
         https://example.com/article-three
   - type: textarea
     id: notes
     attributes:
-      label: Notes
-      description: Optional translator hints (tone, terms to keep in English, sections to skip).
+      label: 备注
+      description: 可选。语气、保留英文的术语、跳过的章节等。

--- a/.github/agents/article-translator.agent.md
+++ b/.github/agents/article-translator.agent.md
@@ -10,7 +10,7 @@ Always load and follow the skill `.github/skills/translating-articles/SKILL.md`.
 
 When assigned an issue or pull request:
 
-1. Collect article URLs from the issue body and any `_inbox/*.source.md` files.
+1. Collect article URLs from the issue body and any `_inbox/*.source.md` files. If you were started from a Cursor chat URL instead of an existing issue, run `python3 scripts/queue_translation.py --create` first so GitHub and Cursor share one `[Translate]` issue.
 2. Prefer inbox source files — GitHub Actions fetches them because you may not be able to browse the live page.
 3. If inbox files are missing, run `python scripts/article_tools.py --url <URL> --outdir _inbox`.
 4. Run `python scripts/capture_media.py --inbox _inbox --repo-root .` when media comments exist.

--- a/.github/agents/article-translator.agent.md
+++ b/.github/agents/article-translator.agent.md
@@ -14,7 +14,7 @@ When assigned an issue or pull request:
 2. Prefer inbox source files — GitHub Actions fetches them because you may not be able to browse the live page.
 3. If inbox files are missing, run `python scripts/article_tools.py --url <URL> --outdir _inbox`.
 4. Run `python scripts/capture_media.py --inbox _inbox --repo-root .` when media comments exist.
-5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub), update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source.
+5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub). Use inbox `title_zh` as `title` when present. Update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source.
 6. Do not change unrelated translations.
 
 If a URL cannot be fetched and there is no inbox file, comment on the issue with the error and stop. Do not guess the article body.

--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -27,7 +27,7 @@ Skip a URL if it already appears in `README.md` or `archive/**/*.md`.
 - Do **not** put `【翻译】` in the filename or H1.
 - Short GIFs: `assets/<slug>/yt-<id>.gif`, `video-N.gif`, or `section-N.gif`.
 
-Copy inbox `author` / `published_at` / `cover_image` when present. You still write `title`, `title_en`, `tech_domain`, `tags`, `translated_at`.
+Copy inbox `author` / `published_at` / `cover_image` when present. If inbox has `title_zh`, use it as `title`. You still write `title_en`, `tech_domain`, `tags`, `translated_at`.
 
 ```yaml
 ---

--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -1,11 +1,33 @@
 ---
 name: translating-articles
-description: Use when translating an English technical article into this repo from a URL, GitHub issue labeled translate, _inbox/*.source.md file, Copilot article-translator agent, or a request to 翻译 / translate an article.
+description: Use when translating an English technical article into this repo from a URL pasted in Cursor, a GitHub issue titled [Translate], _inbox/*.source.md, Copilot article-translator, or a request to 翻译 / translate. Cursor-chat URLs must create a GitHub issue first.
 ---
 
 # Translating articles
 
 Turn an English article URL into a Simplified Chinese markdown post that matches `docs/superpowers/specs/2026-08-22-translation-format-design.md`.
+
+There are **two entry points**. Both become a GitHub Issue titled `[Translate] …`, which starts `Translate article` (fetch `_inbox/`, optional Copilot assign). Do not invent a third private path.
+
+## Mode A — GitHub Issue
+
+The user opened [翻译文章](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml). The Action should already be fetching. Prefer `_inbox/*.source.md` on `translate/issue-<n>`. Then write the Chinese post.
+
+## Mode B — URL pasted in Cursor
+
+The user pasted link(s) in chat (optional Chinese title). **Create the same Issue first**, then translate. Do not only write files locally and skip GitHub.
+
+```bash
+python3 scripts/queue_translation.py --create --url URL --title-zh '中文标题'
+# more articles:
+python3 scripts/queue_translation.py --create --url URL1 --title-zh '第一篇' --pair 'URL2 | 第二篇'
+```
+
+That script writes the form fields (`原文链接` / `中文标题` / `更多文章`) so the Action parser matches a human-submitted issue. Title is `[Translate] …`.
+
+If `gh issue create` fails, say so, then fetch locally and still translate.
+
+After the issue exists, finish the Chinese post here if Copilot did not pick it up: use inbox files when they appear, otherwise `python scripts/article_tools.py --url URL --outdir _inbox`. Mention the issue URL in the translation PR.
 
 ## Inputs
 

--- a/.github/workflows/translate-article.yml
+++ b/.github/workflows/translate-article.yml
@@ -2,7 +2,7 @@ name: Translate article
 
 on:
   issues:
-    types: [opened, labeled]
+    types: [opened, labeled, reopened]
   workflow_dispatch:
     inputs:
       url:
@@ -23,8 +23,10 @@ jobs:
   queue:
     if: >
       github.event_name == 'workflow_dispatch' ||
-      (github.event.action == 'opened' && contains(join(github.event.issue.labels.*.name, ','), 'translate')) ||
-      (github.event.action == 'labeled' && github.event.label.name == 'translate')
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'translate') ||
+      (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'reopened') &&
+        (contains(join(github.event.issue.labels.*.name, ','), 'translate') ||
+         startsWith(github.event.issue.title, '[Translate]')))
     runs-on: ubuntu-latest
     steps:
       - name: Skip if already queued
@@ -39,6 +41,14 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Ensure translate labels exist
+        if: steps.guard.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create translate --color 0E8A16 --description "Queue an article URL for translation" 2>/dev/null || true
+          gh label create translation-queued --color 5319E7 --description "Inbox fetch already ran for this issue" 2>/dev/null || true
+
       - uses: actions/checkout@v4
         if: steps.guard.outputs.skip != 'true'
 
@@ -49,11 +59,15 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body || '' }}
           DISPATCH_URL: ${{ github.event.inputs.url || '' }}
           ISSUE_NUMBER: ${{ github.event.issue.number || '' }}
+          ISSUE_TITLE: ${{ github.event.issue.title || '' }}
         run: |
           printf '%s\n' "$ISSUE_BODY" > /tmp/issue-body.md
           ARGS=(--body-file /tmp/issue-body.md --outdir _inbox --repo-root .)
           if [[ -n "$ISSUE_NUMBER" ]]; then
             ARGS+=(--issue "$ISSUE_NUMBER")
+          fi
+          if [[ -n "$ISSUE_TITLE" ]]; then
+            ARGS+=(--issue-title "$ISSUE_TITLE")
           fi
           if [[ -n "$DISPATCH_URL" ]]; then
             ARGS+=(--url "$DISPATCH_URL")
@@ -112,7 +126,7 @@ jobs:
 
           $URL_LIST
 
-          Next: assign **Copilot** with custom agent \`article-translator\`, or run a Cursor agent with the translating-articles skill. Translate \`_inbox/*.source.md\`, update \`README.md\`, and delete the inbox files.
+          Next: assign **Copilot** with custom agent \`article-translator\`, or run a Cursor agent with the translating-articles skill. Translate \`_inbox/*.source.md\` into \`archive/<date>/<domain>/\`, refresh the README catalog, and delete the inbox files. Use inbox \`title_zh\` when present.
 
           Skill: \`.github/skills/translating-articles/SKILL.md\`
           EOF
@@ -154,9 +168,9 @@ jobs:
               echo "Pull request: $PR_URL"
               echo "Inbox branch: \`$BRANCH\`"
               echo
-              echo "To finish: assign Copilot (custom agent **article-translator**) or start a Cursor agent. Prefer the fetched \`_inbox/*.source.md\` files over re-downloading the page."
+              echo "下一步：若未自动指派 Copilot，请在本 Issue 指派 Copilot（自定义 agent **article-translator**），或开 Cursor agent。优先用已抓取的 \`_inbox/*.source.md\`，inbox 里的 \`title_zh\` 就是指定的中文标题。"
             else
-              echo "No new inbox files were created. Add a public article URL and the \`translate\` label, or check the errors above."
+              echo "没有生成新的 inbox 文件。请确认填了公开文章链接。标题以 \`[Translate]\` 开头，或重新打开 Issue / 补上 \`translate\` 标签即可再跑。"
             fi
           } > /tmp/comment.md
           gh issue comment "$ISSUE_NUMBER" --body-file /tmp/comment.md

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## 怎么用
 
-1. 打开 [Translate article](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml) Issue，贴上原文链接（可以多个）。
-2. GitHub Action 把正文抓进 `_inbox/`，并开 inbox PR。
-3. 在 Issue 上指派 Copilot，选用自定义 agent **article-translator**；或在 Cursor 里按 [translating-articles](.github/skills/translating-articles/SKILL.md) 技能译完。
+1. 打开 [翻译文章](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml) Issue。
+2. 一篇：填原文链接，可选填中文标题。多篇：在「更多文章」里每行 `链接` 或 `链接 | 中文标题`，不要共用一个标题。
+3. 提交即可。Action 会抓原文、开 inbox PR；仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。否则在 Issue 上指派 Copilot（agent **article-translator**），或开 Cursor agent。
 
-也可以在 **Actions → Translate article** 里直接跑工作流。重试失败任务时，去掉 `translation-queued` 再贴回 `translate`。
+重试：关掉再打开 Issue，或补上 `translate` 标签。也可以在 **Actions → Translate article** 里直接跑。
 
 说明见 [docs/translating-articles.md](docs/translating-articles.md)。新译文格式见 [2026-08-22-translation-format-design.md](docs/superpowers/specs/2026-08-22-translation-format-design.md)。
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 
 ## 怎么用
 
-1. 打开 [翻译文章](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml) Issue。
-2. 一篇：填原文链接，可选填中文标题。多篇：在「更多文章」里每行 `链接` 或 `链接 | 中文标题`，不要共用一个标题。
-3. 提交即可。Action 会抓原文、开 inbox PR；仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。否则在 Issue 上指派 Copilot（agent **article-translator**），或开 Cursor agent。
+两种入口，最后都变成一个 `[Translate]` Issue，再由 Action 抓原文：
+
+1. **GitHub：** 打开 [翻译文章](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml)。一篇填链接和可选中文标题；多篇在「更多文章」里每行 `链接` 或 `链接 | 中文标题`。
+2. **Cursor：** 在对话里直接贴网址（可带中文标题）。Agent 先跑 `python3 scripts/queue_translation.py --create --url …` 创建同样格式的 Issue，再写译文。不要只在本地改文件、不建 Issue。
+
+提交 Issue 后 Action 会抓原文、开 inbox PR。仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。Cursor 对话里贴的链接，由当前 agent 在建 Issue 之后把译文写完。
 
 重试：关掉再打开 Issue，或补上 `translate` 标签。也可以在 **Actions → Translate article** 里直接跑。
 
@@ -26,6 +29,7 @@
 | `scripts/translation_format.py` | 译文校验、领域提示、时长门槛 |
 | `scripts/translation_archive.py` | 译文归档路径和 README 目录 |
 | `scripts/rebuild_readme.py` | 按 `archive/` 重生成 README 译文列表 |
+| `scripts/queue_translation.py` | Cursor 用同一套 Issue 正文创建 `[Translate]` 工单 |
 
 ## 译文
 

--- a/docs/superpowers/specs/2026-08-22-article-translator-design.md
+++ b/docs/superpowers/specs/2026-08-22-article-translator-design.md
@@ -4,7 +4,7 @@ Daily English article URLs become Chinese markdown translations in this repo, ma
 
 ## Daily flow
 
-1. Open a **Translate article** issue (or paste URLs into an issue and add the `translate` label), or run the **Translate article** workflow with a URL.
+1. Open a **翻译文章** issue (title starts with `[Translate]`, optional Chinese title, extra articles as `URL | 中文标题`), or run the **Translate article** workflow with a URL.
 2. GitHub Action extracts `http(s)` links, fetches each article, and writes `_inbox/<slug>.source.md` on branch `translate/issue-<n>` (or `translate/manual-<run>`).
 3. The Action opens a pull request and comments on the issue. If `COPILOT_ASSIGN_TOKEN` is set, it assigns Copilot cloud agent with custom agent `article-translator` and `base_branch` set to that inbox branch so the agent can read the fetched source (cloud agent cannot reliably browse the live web).
 4. The agent (GitHub Copilot **or** Cursor) translates `_inbox/*.source.md` into `archive/<translated_at>/<tech_domain>/`, updates the README catalog, and removes the inbox source.

--- a/docs/translating-articles.md
+++ b/docs/translating-articles.md
@@ -6,9 +6,12 @@ New posts use the template in [the translation format spec](superpowers/specs/20
 
 ## Submit a URL
 
-1. Open **[翻译文章](../../issues/new?template=translate-article.yml)**.
-2. One article: paste the URL and optionally a Chinese title. Several articles: one `URL` or `URL | 中文标题` per line in **更多文章**.
-3. Submit. The Action fetches the page into `_inbox/` and opens a PR. If `COPILOT_ASSIGN_TOKEN` is set, it assigns Copilot to write the Chinese post. Otherwise assign **article-translator** on the issue, or start a Cursor agent.
+Two entry points, one Issue format:
+
+1. **GitHub:** open **[翻译文章](../../issues/new?template=translate-article.yml)**. One article: URL + optional Chinese title. Several articles: `URL` or `URL | 中文标题` per line in **更多文章**.
+2. **Cursor:** paste URL(s) in chat. The agent runs `python3 scripts/queue_translation.py --create --url …` to open the same Issue, then writes the translation if Copilot does not.
+
+The Action fetches `_inbox/` after the Issue is opened. If `COPILOT_ASSIGN_TOKEN` is set, it also assigns Copilot.
 
 To retry, reopen the issue or add the `translate` label. The issue title should start with `[Translate]`.
 

--- a/docs/translating-articles.md
+++ b/docs/translating-articles.md
@@ -6,14 +6,11 @@ New posts use the template in [the translation format spec](superpowers/specs/20
 
 ## Submit a URL
 
-1. Open **[Translate article](../../issues/new?template=translate-article.yml)** and paste the link (more than one URL is OK).
-2. Wait for the Action to comment with an inbox pull request under `_inbox/`.
-3. Finish the translation:
+1. Open **[翻译文章](../../issues/new?template=translate-article.yml)**.
+2. One article: paste the URL and optionally a Chinese title. Several articles: one `URL` or `URL | 中文标题` per line in **更多文章**.
+3. Submit. The Action fetches the page into `_inbox/` and opens a PR. If `COPILOT_ASSIGN_TOKEN` is set, it assigns Copilot to write the Chinese post. Otherwise assign **article-translator** on the issue, or start a Cursor agent.
 
-   - **GitHub Copilot:** on the issue, assign **Copilot** and choose custom agent **article-translator**.
-   - **Cursor:** start an agent on the inbox branch and ask it to translate using the translating-articles skill.
-
-To retry a failed issue, remove the `translation-queued` label and add `translate` again.
+To retry, reopen the issue or add the `translate` label. The issue title should start with `[Translate]`.
 
 You can also run **Actions → Translate article → Run workflow** and paste a URL.
 

--- a/scripts/article_tools.py
+++ b/scripts/article_tools.py
@@ -139,6 +139,47 @@ def parse_issue_requests(body: str, issue_title: str | None = None) -> list[dict
     return requests
 
 
+def format_translate_issue(
+    requests: list[dict[str, str | None]],
+    notes: str | None = None,
+) -> tuple[str, str]:
+    """Build the same GitHub form body Cursor or a human would submit."""
+    if not requests:
+        raise ValueError("Need at least one article URL")
+    first = requests[0]
+    first_url = first.get("url") or ""
+    first_title = first.get("title_zh") or None
+    issue_title = f"[Translate] {first_title or slug_from_url(first_url)}"
+    extras: list[str] = []
+    for item in requests[1:]:
+        url = item.get("url") or ""
+        if not url:
+            continue
+        title = item.get("title_zh")
+        extras.append(f"{url} | {title}" if title else url)
+    body = "\n".join(
+        [
+            "### 原文链接",
+            "",
+            first_url,
+            "",
+            "### 中文标题",
+            "",
+            first_title or "_No response_",
+            "",
+            "### 更多文章",
+            "",
+            "\n".join(extras) if extras else "_No response_",
+            "",
+            "### 备注",
+            "",
+            notes.strip() if notes and not _is_empty_form_value(notes) else "_No response_",
+            "",
+        ]
+    )
+    return issue_title, body
+
+
 def extract_urls(text: str) -> list[str]:
     """Return unique http(s) article URLs, skipping GitHub attachment noise when possible."""
     seen: set[str] = set()

--- a/scripts/article_tools.py
+++ b/scripts/article_tools.py
@@ -50,6 +50,93 @@ class FetchedArticle:
     cover_image: str | None = None
     media_comments: list[str] | None = None
     section_snippets: list[str] | None = None
+    title_zh: str | None = None
+
+
+EMPTY_FORM_VALUES = {
+    "",
+    "_no response_",
+    "no response",
+    "无",
+    "没有",
+    "n/a",
+    "none",
+}
+TITLE_FIELD_NAMES = {"中文标题", "translation title", "article title"}
+URL_FIELD_NAMES = {"原文链接", "article url"}
+EXTRA_FIELD_NAMES = {"更多文章", "additional urls"}
+TRANSLATE_TITLE_RE = re.compile(r"^\[translate\]\s*", re.I)
+
+
+def _is_empty_form_value(text: str | None) -> bool:
+    return (text or "").strip().lower() in EMPTY_FORM_VALUES
+
+
+def parse_issue_sections(text: str) -> dict[str, str]:
+    sections: dict[str, str] = {}
+    parts = re.split(r"^### ", text or "", flags=re.MULTILINE)
+    for part in parts[1:]:
+        heading, _, rest = part.partition("\n")
+        sections[heading.strip()] = rest.strip()
+    return sections
+
+
+def _title_from_issue_title(issue_title: str | None) -> str | None:
+    if not issue_title:
+        return None
+    cleaned = TRANSLATE_TITLE_RE.sub("", issue_title).strip()
+    return cleaned or None
+
+
+def parse_issue_requests(body: str, issue_title: str | None = None) -> list[dict[str, str | None]]:
+    """Read URLs and optional Chinese titles from a Translate-article issue."""
+    sections = parse_issue_sections(body)
+    named = ""
+    primary = ""
+    extra = ""
+    for heading, value in sections.items():
+        key = heading.strip().lower()
+        if key in TITLE_FIELD_NAMES:
+            named = value
+        elif key in URL_FIELD_NAMES:
+            primary = value
+        elif key in EXTRA_FIELD_NAMES:
+            extra = value
+
+    requests: list[dict[str, str | None]] = []
+    seen: set[str] = set()
+
+    def add_blob(blob: str, default_title: str | None = None) -> None:
+        if _is_empty_form_value(blob):
+            return
+        for raw_line in blob.splitlines():
+            line = raw_line.strip()
+            if not line or _is_empty_form_value(line):
+                continue
+            title = default_title
+            url_part = line
+            if "|" in line:
+                left, right = line.split("|", 1)
+                url_part = left.strip()
+                title = right.strip() or default_title
+            found = extract_urls(url_part) or extract_urls(line)
+            if not found:
+                continue
+            url = found[0]
+            if url in seen:
+                continue
+            seen.add(url)
+            requests.append({"url": url, "title_zh": title or None})
+
+    add_blob(primary, None if _is_empty_form_value(named) else named.strip())
+    add_blob(extra)
+    if not requests:
+        add_blob(body)
+
+    hint = _title_from_issue_title(issue_title)
+    if requests and not requests[0]["title_zh"] and hint:
+        requests[0]["title_zh"] = hint
+    return requests
 
 
 def extract_urls(text: str) -> list[str]:
@@ -134,6 +221,8 @@ def format_source_markdown(article: FetchedArticle, issue: str | None = None) ->
         lines.append(f"published_at: {article.published_at}")
     if article.cover_image:
         lines.append(f"cover_image: {article.cover_image}")
+    if article.title_zh:
+        lines.append(f"title_zh: {article.title_zh}")
     body = article.markdown.strip()
     extras = [c.strip() for c in (article.media_comments or []) if c.strip()]
     for comment in extras:
@@ -610,28 +699,33 @@ def prepare_inbox(
     repo_root: Path,
     issue: str | None = None,
     urls: Iterable[str] | None = None,
+    issue_title: str | None = None,
 ) -> dict:
-    found = extract_urls(body)
+    requests = parse_issue_requests(body, issue_title=issue_title)
     for extra in urls or []:
         extra = extra.strip()
-        if extra and extra not in found:
-            found.append(extra)
+        if extra and extra not in {item["url"] for item in requests}:
+            requests.append({"url": extra, "title_zh": None})
+    found = [item["url"] for item in requests if item.get("url")]
     results: dict = {"urls": found, "files": [], "skipped": [], "errors": []}
     if not found:
         results["errors"].append("No http(s) article URLs found.")
         return results
 
-    for url in found:
+    for item in requests:
+        url = item["url"]
         if already_translated(repo_root, url):
             results["skipped"].append({"url": url, "reason": "already present in repo markdown"})
             continue
         try:
             article = fetch_article(url)
+            article.title_zh = item.get("title_zh")
             path = write_inbox(article, outdir, issue=issue)
             results["files"].append(
                 {
                     "url": url,
                     "title": article.title,
+                    "title_zh": article.title_zh,
                     "path": str(path.relative_to(repo_root)),
                     "method": article.method,
                 }
@@ -652,12 +746,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--outdir", default="_inbox")
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--issue")
+    parser.add_argument("--issue-title")
     args = parser.parse_args(argv)
 
     repo_root = Path(args.repo_root).resolve()
     outdir = (repo_root / args.outdir).resolve()
     body = Path(args.body_file).read_text(encoding="utf-8") if args.body_file else ""
-    result = prepare_inbox(body, outdir, repo_root, issue=args.issue, urls=args.url)
+    result = prepare_inbox(
+        body,
+        outdir,
+        repo_root,
+        issue=args.issue,
+        urls=args.url,
+        issue_title=args.issue_title,
+    )
     json.dump(result, sys.stdout, ensure_ascii=False, indent=2)
     sys.stdout.write("\n")
     if result["errors"] and not result["files"]:

--- a/scripts/queue_translation.py
+++ b/scripts/queue_translation.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Queue translations the same way a GitHub Issue form would."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import article_tools  # noqa: E402
+
+
+def _requests_from_args(urls: list[str], pairs: list[str], title_zh: str | None) -> list[dict[str, str | None]]:
+    requests: list[dict[str, str | None]] = []
+    for index, url in enumerate(urls):
+        parsed = article_tools.parse_issue_requests(url)
+        if not parsed:
+            continue
+        if index == 0 and title_zh and not parsed[0]["title_zh"]:
+            parsed[0]["title_zh"] = title_zh
+        requests.extend(parsed)
+    for raw in pairs:
+        parsed = article_tools.parse_issue_requests(raw)
+        requests.extend(parsed)
+    seen: set[str] = set()
+    unique: list[dict[str, str | None]] = []
+    for item in requests:
+        url = item.get("url")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        unique.append(item)
+    return unique
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Format or create a [Translate] GitHub issue from URLs"
+    )
+    parser.add_argument("--url", action="append", default=[], help="Article URL (repeatable)")
+    parser.add_argument(
+        "--pair",
+        action="append",
+        default=[],
+        help="One line: URL or URL | 中文标题",
+    )
+    parser.add_argument("--title-zh", help="Chinese title for the first --url")
+    parser.add_argument("--notes")
+    parser.add_argument(
+        "--create",
+        action="store_true",
+        help="Create the GitHub issue with gh (triggers the Translate article Action)",
+    )
+    parser.add_argument("--repo", default="lihenair/techtranslate")
+    args = parser.parse_args(argv)
+
+    requests = _requests_from_args(args.url, args.pair, args.title_zh)
+    if not requests:
+        print("No article URLs found.", file=sys.stderr)
+        return 1
+    title, body = article_tools.format_translate_issue(requests, notes=args.notes)
+    payload = {"title": title, "body": body, "requests": requests}
+    if not args.create:
+        json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        args.repo,
+        "--title",
+        title,
+        "--body",
+        body,
+    ]
+    try:
+        created = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        print(detail.strip() or "gh issue create failed", file=sys.stderr)
+        json.dump({**payload, "created": False}, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 1
+    url = created.stdout.strip()
+    json.dump({**payload, "created": True, "issue_url": url}, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_article_tools.py
+++ b/tests/test_article_tools.py
@@ -22,6 +22,77 @@ https://github.com/lihenair/techtranslate/assets/123/image.png
 """
 
 
+class IssueRequestTest(unittest.TestCase):
+    def test_parses_form_url_and_chinese_title(self) -> None:
+        body = """### 原文链接
+
+https://www.jacobpeake.com/ai-chip-architectures
+
+### 中文标题
+
+AI 芯片架构
+
+### 更多文章
+
+_No response_
+"""
+        reqs = article_tools.parse_issue_requests(body, issue_title="[Translate] ignored")
+        self.assertEqual(
+            reqs,
+            [
+                {
+                    "url": "https://www.jacobpeake.com/ai-chip-architectures",
+                    "title_zh": "AI 芯片架构",
+                }
+            ],
+        )
+
+    def test_parses_extra_lines_with_optional_title(self) -> None:
+        body = """### 原文链接
+
+https://example.com/one
+
+### 中文标题
+
+第一篇
+
+### 更多文章
+
+https://example.com/two | 第二篇
+https://example.com/three
+"""
+        reqs = article_tools.parse_issue_requests(body)
+        self.assertEqual(
+            [item["url"] for item in reqs],
+            ["https://example.com/one", "https://example.com/two", "https://example.com/three"],
+        )
+        self.assertEqual([item["title_zh"] for item in reqs], ["第一篇", "第二篇", None])
+
+    def test_uses_issue_title_when_form_title_missing(self) -> None:
+        body = """### Article URL
+
+https://www.jacobpeake.com/ai-chip-architectures
+
+### Additional URLs
+
+_No response_
+"""
+        reqs = article_tools.parse_issue_requests(
+            body, issue_title="[Translate] AI Chip Architectures"
+        )
+        self.assertEqual(reqs[0]["title_zh"], "AI Chip Architectures")
+
+    def test_old_additional_urls_still_work(self) -> None:
+        reqs = article_tools.parse_issue_requests(ISSUE_BODY)
+        self.assertEqual(
+            [item["url"] for item in reqs],
+            [
+                "https://medium.com/mobile-app-development-publication/android-jetpack-compose-compositionlocal-made-easy-8632b201bfcd",
+                "https://www.baeldung.com/kotlin/contracts",
+            ],
+        )
+
+
 class ExtractUrlsTest(unittest.TestCase):
     def test_extracts_unique_http_urls_and_strips_punctuation(self) -> None:
         urls = article_tools.extract_urls(ISSUE_BODY)
@@ -88,6 +159,17 @@ class InboxFormatTest(unittest.TestCase):
         self.assertIn("issue: 12", text)
         self.assertIn("# Hello Compose", text)
         self.assertIn("Body text here.", text)
+
+    def test_source_markdown_writes_requested_chinese_title(self) -> None:
+        article = article_tools.FetchedArticle(
+            url="https://example.com/a",
+            title="Hello Compose",
+            markdown="Body text here.",
+            method="jina",
+            title_zh="你好 Compose",
+        )
+        text = article_tools.format_source_markdown(article, issue="8")
+        self.assertIn("title_zh: 你好 Compose", text)
 
     def test_source_markdown_writes_optional_meta(self) -> None:
         article = article_tools.FetchedArticle(

--- a/tests/test_article_tools.py
+++ b/tests/test_article_tools.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -81,6 +83,42 @@ _No response_
             body, issue_title="[Translate] AI Chip Architectures"
         )
         self.assertEqual(reqs[0]["title_zh"], "AI Chip Architectures")
+
+    def test_format_round_trips_through_the_issue_parser(self) -> None:
+        requests = [
+            {"url": "https://example.com/one", "title_zh": "第一篇"},
+            {"url": "https://example.com/two", "title_zh": "第二篇"},
+            {"url": "https://example.com/three", "title_zh": None},
+        ]
+        title, body = article_tools.format_translate_issue(requests, notes="keep API names")
+        self.assertEqual(title, "[Translate] 第一篇")
+        parsed = article_tools.parse_issue_requests(body, issue_title=title)
+        self.assertEqual(parsed, requests)
+        self.assertIn("keep API names", body)
+
+    def test_queue_script_prints_issue_without_creating(self) -> None:
+        out = subprocess.check_output(
+            [
+                sys.executable,
+                str(ROOT / "scripts" / "queue_translation.py"),
+                "--url",
+                "https://example.com/a",
+                "--title-zh",
+                "甲",
+                "--pair",
+                "https://example.com/b | 乙",
+            ],
+            text=True,
+        )
+        data = json.loads(out)
+        self.assertEqual(data["title"], "[Translate] 甲")
+        self.assertEqual(
+            [item["url"] for item in data["requests"]],
+            ["https://example.com/a", "https://example.com/b"],
+        )
+        parsed = article_tools.parse_issue_requests(data["body"], issue_title=data["title"])
+        self.assertEqual(parsed[0]["title_zh"], "甲")
+        self.assertEqual(parsed[1]["title_zh"], "乙")
 
     def test_old_additional_urls_still_work(self) -> None:
         reqs = article_tools.parse_issue_requests(ISSUE_BODY)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
两种入口共用一份 `[Translate]` Issue 正文，再触发 Action：

1. **GitHub：** 用「翻译文章」表单提交。一篇填链接 + 可选中文标题；多篇每行 `链接 | 中文标题`。
2. **Cursor：** 对话里贴网址。Agent 先跑 `python3 scripts/queue_translation.py --create --url …` 创建同样格式的 Issue，再写译文。禁止只改本地文件、不建 Issue。

标题以 `[Translate]` 开头就会跑抓取，不再依赖仓库里事先有 `translate` 标签。指定的中文标题写入 inbox `title_zh`。

GitHub Action 在没配 `COPILOT_ASSIGN_TOKEN` 时不会自己写中文；Cursor 对话这条路径由当前 agent 在建 Issue 之后把译文写完。

`python3 -m unittest discover -s tests -v`：58 tests OK。

合进 master 后，把 #8 关掉再打开即可补跑 AI Chip Architectures。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b05ed7ca-ee39-494c-b3e3-6e4d580747f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b05ed7ca-ee39-494c-b3e3-6e4d580747f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

