### PR TITLE
fix: 没有短视频时不要因为缺 assets/ 导致排队失败

### DIFF
--- a/.github/workflows/translate-article.yml
+++ b/.github/workflows/translate-article.yml
@@ -112,7 +112,7 @@ jobs:
           fi
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           git checkout -B "$BRANCH"
-          git add _inbox assets
+          python3 scripts/article_tools.py --stage-inbox --repo-root .
           if git diff --cached --quiet; then
             echo "No inbox files to commit"
             exit 0

--- a/scripts/article_tools.py
+++ b/scripts/article_tools.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import re
 import ssl
+import subprocess
 import sys
 import time
 from dataclasses import asdict, dataclass
@@ -734,6 +735,22 @@ def write_inbox(article: FetchedArticle, outdir: Path, issue: str | None = None)
     return path
 
 
+def inbox_git_add_paths(repo_root: Path) -> list[str]:
+    """Paths the queue Action may commit. Skip missing dirs so git add does not fail."""
+    paths: list[str] = []
+    for name in ("_inbox", "assets"):
+        if (repo_root / name).exists():
+            paths.append(name)
+    return paths
+
+
+def stage_inbox_paths(repo_root: Path) -> list[str]:
+    paths = inbox_git_add_paths(repo_root)
+    if paths:
+        subprocess.run(["git", "add", "--", *paths], cwd=repo_root, check=True)
+    return paths
+
+
 def prepare_inbox(
     body: str,
     outdir: Path,
@@ -788,9 +805,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--issue")
     parser.add_argument("--issue-title")
+    parser.add_argument(
+        "--stage-inbox",
+        action="store_true",
+        help="git add _inbox and assets only when those paths exist",
+    )
     args = parser.parse_args(argv)
 
     repo_root = Path(args.repo_root).resolve()
+    if args.stage_inbox:
+        stage_inbox_paths(repo_root)
+        return 0
     outdir = (repo_root / args.outdir).resolve()
     body = Path(args.body_file).read_text(encoding="utf-8") if args.body_file else ""
     result = prepare_inbox(

--- a/tests/test_article_tools.py
+++ b/tests/test_article_tools.py
@@ -489,5 +489,58 @@ class MergeHtmlEnrichmentTest(unittest.TestCase):
         self.assertEqual(merged.cover_image, "https://example.com/jina.png")
 
 
+class InboxGitAddTest(unittest.TestCase):
+    def test_paths_omit_missing_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "_inbox").mkdir()
+            (root / "_inbox" / "article.source.md").write_text("x", encoding="utf-8")
+            self.assertEqual(article_tools.inbox_git_add_paths(root), ["_inbox"])
+
+    def test_paths_include_assets_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "_inbox").mkdir()
+            (root / "assets" / "slug").mkdir(parents=True)
+            (root / "assets" / "slug" / "video-1.gif").write_bytes(b"GIF")
+            self.assertEqual(article_tools.inbox_git_add_paths(root), ["_inbox", "assets"])
+
+    def test_git_add_succeeds_without_assets_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "_inbox").mkdir()
+            (root / "_inbox" / "article.source.md").write_text("x", encoding="utf-8")
+            subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "config", "user.email", "test@example.com"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "test"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            broken = subprocess.run(
+                ["git", "add", "_inbox", "assets"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(broken.returncode, 0)
+            self.assertIn("assets", broken.stderr)
+            article_tools.stage_inbox_paths(root)
+            staged = subprocess.run(
+                ["git", "diff", "--cached", "--name-only"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("_inbox/article.source.md", staged.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Issue #10 已经触发了 `Translate article`（run [32624676687](https://github.com/lihenair/techtranslate/actions/runs/32624676687)），抓取 inbox 成功，但在 `git add _inbox assets` 处失败：

```
fatal: pathspec 'assets' did not match any files
```

这篇没有 ≤15s 短视频，仓库里也就没有 `assets/`。后续开 PR、评论 Issue、打 `translation-queued` 标签都被跳过。

## 修复

只 `git add` 实际存在的 `_inbox` / `assets`。补了回归测试。

合入 master 后需要再触发一次 #10（reopen 或 `workflow_dispatch`），才能验证整条流水线。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b05ed7ca-ee39-494c-b3e3-6e4d580747f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b05ed7ca-ee39-494c-b3e3-6e4d580747f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

