### PR TITLE
关掉已译完的 Translate Issue，inbox PR 不再 Closes

### DIFF
--- a/.github/agents/article-translator.agent.md
+++ b/.github/agents/article-translator.agent.md
@@ -14,7 +14,7 @@ When assigned an issue or pull request:
 2. Prefer inbox source files — GitHub Actions fetches them because you may not be able to browse the live page.
 3. If inbox files are missing, run `python scripts/article_tools.py --url <URL> --outdir _inbox`.
 4. Run `python scripts/capture_media.py --inbox _inbox --repo-root .` when media comments exist.
-5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub). Use inbox `title_zh` as `title` when present. Update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source.
+5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub). Use inbox `title_zh` as `title` when present. Update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source. The translation PR body must include `Closes #<issue>`. Close the Action inbox PR without merging it.
 6. Do not change unrelated translations.
 
 If a URL cannot be fetched and there is no inbox file, comment on the issue with the error and stop. Do not guess the article body.

--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -139,7 +139,9 @@ Delete the matching `_inbox/*.source.md`. Keep `assets/<slug>/` GIFs that the tr
 
 ## Done
 
-Open or update a pull request with the translation, README, and any `assets/<slug>/` files. Validate before you finish:
+Open or update a pull request with the translation, README, and any `assets/<slug>/` files. The PR body **must** include `Closes #<issue>` so GitHub closes the `[Translate]` issue when this PR merges. Do **not** put `Closes #<issue>` on the Action inbox PR (that one is only English `_inbox/`). After the translation PR exists, close the leftover inbox PR without merging it.
+
+Validate before you finish:
 
 ```bash
 python3 -c "import sys, pathlib; sys.path.insert(0,'scripts'); import translation_format; print(translation_format.validate_translation(pathlib.Path('FILE.md').read_text()))"

--- a/.github/workflows/translate-article.yml
+++ b/.github/workflows/translate-article.yml
@@ -132,7 +132,7 @@ jobs:
           EOF
           )
           if [[ -n "$ISSUE_NUMBER" ]]; then
-            PR_BODY+=$'\n\n'"Closes #${ISSUE_NUMBER}"
+            PR_BODY+=$'\n\n'"Related to #${ISSUE_NUMBER}. Do not merge this inbox PR to close the issue — the translation PR must say \`Closes #${ISSUE_NUMBER}\`."
           fi
           PR_URL=$(gh pr list --head "$BRANCH" --json url --jq '.[0].url' || true)
           if [[ -z "$PR_URL" ]]; then

--- a/docs/translating-articles.md
+++ b/docs/translating-articles.md
@@ -11,7 +11,7 @@ Two entry points, one Issue format:
 1. **GitHub:** open **[翻译文章](../../issues/new?template=translate-article.yml)**. One article: URL + optional Chinese title. Several articles: `URL` or `URL | 中文标题` per line in **更多文章**.
 2. **Cursor:** paste URL(s) in chat. The agent runs `python3 scripts/queue_translation.py --create --url …` to open the same Issue, then writes the translation if Copilot does not.
 
-The Action fetches `_inbox/` after the Issue is opened. If `COPILOT_ASSIGN_TOKEN` is set, it also assigns Copilot.
+The Action fetches `_inbox/` after the Issue is opened and opens an inbox PR. That PR is only English source; it must **not** say `Closes #<issue>`. The translation PR closes the Issue. If `COPILOT_ASSIGN_TOKEN` is set, the Action also assigns Copilot.
 
 To retry, reopen the issue or add the `translate` label. The issue title should start with `[Translate]`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#19 和 #22 的译文已经在 master 上，但 Issue 还开着。

原因：Action 的 inbox PR（只抓英文 `_inbox/`）写了 `Closes #19` / `Closes #22`。GitHub 把关单绑在那个没合进去的 inbox PR 上。后来的译文 PR 只写了「Issue：链接」，没有 `Closes #N`。

这次改动：

- inbox PR 改成 `Related to #N`，不再 `Closes`
- 译文 PR / skill 要求写 `Closes #<issue>`，并关掉多余的 inbox PR

Closes #19
Closes #22

已关掉没合入的 inbox PR #20、#23。合入本 PR 后，那两个 Translate Issue 会一起关掉。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b05ed7ca-ee39-494c-b3e3-6e4d580747f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b05ed7ca-ee39-494c-b3e3-6e4d580747f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

