### PR TITLE
fix: 768 台服务器译文配图改用 raw.githubusercontent.com 绝对 URL

### DIFF
--- a/archive/2026-08-23/backend/Making-768-servers-look-like-1.md
+++ b/archive/2026-08-23/backend/Making-768-servers-look-like-1.md
@@ -26,7 +26,7 @@ cover_image: https://planetscale.com/assets/making-768-servers-look-like-1-socia
 
 这是 768 台服务器。
 
-![768 台服务器](../../../../assets/Making-768-servers-look-like-1/visual-servers.gif)
+![768 台服务器](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-servers.gif)
 
 对有些人来说，那看起来像很多台电脑。对那些给几百万用户、每秒几百万次查询的应用管基础设施的人来说，挺正常。这个规模的产品，常常需要几千台服务器一起干活。
 
@@ -40,7 +40,7 @@ cover_image: https://planetscale.com/assets/making-768-servers-look-like-1-socia
 
 先看一种简单的应用架构。
 
-![简单应用架构](../../../../assets/Making-768-servers-look-like-1/visual-popular-arch.gif)
+![简单应用架构](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-popular-arch.gif)
 
 你用过的大多数应用都这样工作，至少早期是这样。客户端设备上的软件经互联网连到应用服务器。应用服务器住在数据中心里，处理鉴权、页面加载，以及应用行为的全部服务端逻辑。用户账号、帖子、设置、消息这类持久化数据，都存在数据库服务器里、再从那里取回来（「数据库服务器」通常是 Postgres 或 MySQL，本文焦点是 Postgres）。
 
@@ -48,13 +48,13 @@ cover_image: https://planetscale.com/assets/making-768-servers-look-like-1-socia
 
 通用可扩展性定律（Universal Scalability Law）把这件事说得很干净：
 
-![通用可扩展性定律](../../../../assets/Making-768-servers-look-like-1/visual-universal-scalability-law.gif)
+![通用可扩展性定律](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-universal-scalability-law.gif)
 
 简而言之，USL 说资源**争用（contention）**会让可扩展性随资源增加呈次线性增长；到某一点，**不连贯（incoherence）**会让性能掉下去。Postgres 如此，任何想在更大服务器上跨很多线程或进程往外扩的软件系统都如此。
 
 短期内解决这个问题的一种办法，是利用读副本（read replica）。
 
-![主库与读副本](../../../../assets/Making-768-servers-look-like-1/visual-primary-replicas.gif)
+![主库与读副本](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-primary-replicas.gif)
 
 这种配置里，你把原来那台留作**主库（primary）**，再按上面那样加**副本（replica）**。
 
@@ -84,7 +84,7 @@ cover_image: https://planetscale.com/assets/making-768-servers-look-like-1-socia
 
 分片靠把数据和查询摊到很多互不相同的主库上，解开这三只瓶颈。对数据有用，是因为单节点只能存这么多，写吞吐也有上限。对查询有用，是因为网络互连和 CPU 一次只能处理这么多查询。
 
-![分片](../../../../assets/Making-768-servers-look-like-1/visual-sharding.gif)
+![分片](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-sharding.gif)
 
 过了几 TB 数据，分片在各种规模上都有用。比如 2 TB 数据，我们可以选四个分片，每个存 500 GB，扛总查询流量的 1/4。要存一个 PB（一百万 GB）时，就需要多得多的分片。这时可以用 256 个分片，每个是主库 + 2 个副本，各自负责存大约 4 TB。这需要 256 × 3 = 768 台服务器！
 
@@ -103,11 +103,11 @@ cover_image: https://planetscale.com/assets/making-768-servers-look-like-1-socia
 
 我们希望应用服务器从跟一套复杂系统交互：
 
-![很多分片](../../../../assets/Making-768-servers-look-like-1/visual-tons-of-shards.gif)
+![很多分片](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-tons-of-shards.gif)
 
 变成只拿一根连接串交互，看起来像在对接一个又大又可扩展的数据库：
 
-![看起来像一台数据库](../../../../assets/Making-768-servers-look-like-1/visual-simple-sharded.gif)
+![看起来像一台数据库](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-simple-sharded.gif)
 
 而实际上用的是几十或几百个分片。[Neki](https://neki.dev) 给 Postgres、[Vitess](https://vitess.io) 给 MySQL 解决这件事。我们来看怎么做。
 
@@ -119,7 +119,7 @@ cover_image: https://planetscale.com/assets/making-768-servers-look-like-1-socia
 
 Postgres 数据库经常用代理。就算没有分片，它们对连接池和请求排队也有用。对普通（未分片）Postgres，PgBouncer 是人们常用的代理，把几千条应用连接复用到更少的直连 Postgres 连接上。
 
-![PgBouncer](../../../../assets/Making-768-servers-look-like-1/visual-pgbouncer.gif)
+![PgBouncer](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-pgbouncer.gif)
 
 PgBouncer 目标很简单。它被做成接受来自很多客户端的大量连接，再经它持续维护的一小池 Postgres 连接转出去。查询排队对流量浪涌和数据库故障转移有用，新主库上线后请求可以接着跑。想了解更多，我们有一整篇 [PgBouncer 博文](https://planetscale.com/blog/scaling-postgres-connections-with-pgbouncer)。
 
@@ -144,7 +144,7 @@ PgBouncer 目标很简单。它被做成接受来自很多客户端的大量连�
 
 四个分片各自被分配一段负责存储的 ID 范围，路由器把插入送到正确的分片。插入先到路由器，它给每个 ID 算哈希，再转发到正确的分片。
 
-![按哈希插入到分片](../../../../assets/Making-768-servers-look-like-1/visual-shard-inserts.gif)
+![按哈希插入到分片](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-shard-inserts.gif)
 
 读的时候，有些查询够简单，路由器直接递给单个分片。
 
@@ -165,7 +165,7 @@ SELECT email FROM user
 
 归根结底，这意味着路由器自己必须内建完整的查询解析器和路由规划器。
 
-![路由器里的查询规划](../../../../assets/Making-768-servers-look-like-1/visual-proxy-plan.gif)
+![路由器里的查询规划](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-proxy-plan.gif)
 
 路由器必须在同一个系统里做查询解析、规划、连接池和缓冲。复杂软件很难做对。
 
@@ -203,7 +203,7 @@ SELECT email FROM user
 
 NLB 的工作很简单：经单个主机/IP 接受连接，再把每个连接分给许多目的地之一。流量就是这样摊到各台路由器上的。一旦分配，连接生命周期里都留在同一个代理上。
 
-![多个代理前面的 NLB](../../../../assets/Making-768-servers-look-like-1/visual-full-sharded.gif)
+![多个代理前面的 NLB](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-full-sharded.gif)
 
 有些情况下不需要 NLB。拿掉 NLB 会让应用服务器的连接逻辑稍复杂一点，因为它得知道每台路由器的主机，但少一跳网络，能把往返延迟压到最低。
 
@@ -217,7 +217,7 @@ NLB 的工作很简单：经单个主机/IP 接受连接，再把每个连接分
 4. 连接先经 NLB，再到 N 个代理之一
 5. 应用开始发数据库查询，路径是 应用 → NLB（可选）→ 代理 → 分片。复杂的路由逻辑对应用隐藏。（为简单起见，下图没画 NLB）
 
-![查询怎么落到各分片](../../../../assets/Making-768-servers-look-like-1/visual-shard-formation.gif)
+![查询怎么落到各分片](https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-shard-formation.gif)
 
 这个例子扩到了 1 PB，但分片应该远在这个规模之前就开始。精确建议取决于每个数据库的大小、模式和 QPS，但我们建议 Postgres 和 MySQL 过了几 TB 就分片。那通常是前面说的瓶颈开始撞上的点：备份太久、写瓶颈，等等。如果你在为扩展关系型数据库发愁，Neki 和 Vitess 就是答案。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub blob / README 预览无法稳定解析 `../../../../assets/` 相对路径，导致 12 张 GIF 配图显示不出来。

将 `archive/2026-08-23/backend/Making-768-servers-look-like-1.md` 中全部本地 assets 引用改为 `raw.githubusercontent.com` 直链，例如：

`https://raw.githubusercontent.com/lihenair/techtranslate/master/assets/Making-768-servers-look-like-1/visual-servers.gif`

`translation_format.validate_translation()` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

