### PR TITLE
fix: 补回「循环与图」正文示意图并修抓取丢图

### DIFF
--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -107,6 +107,7 @@ Omit any header line you cannot fill. Do not use `[原文链接](URL)`.
 ## Body rules
 
 - Simplified Chinese. Keep code, commands, API names, and original raster image URLs (`png` / `jpg` / `webp`). Same-origin diagram iframes and SVG (inline or `.svg`) must be converted into `assets/<slug>/` GIF or PNG; GitHub cannot show those iframes, and Jina drops them. From `archive/<date>/<domain>/` use `../../../../assets/<slug>/visual-….gif`.
+- Copy **every** inbox raster image into the Chinese post at the matching section — not only `cover_image`. X/Twitter long posts often have 3–6 `pbs.twimg.com/media/…` diagrams that Jina keeps and x.com HTML drops. If the Chinese file only has the header cover, the body diagrams are missing.
 - Headings: `## [引言](#introduction)` — Chinese title, original slug.
 - First use of a term: `消毒（sanitization）`.
 - No `iframe`. No `p9-xtjj-sign` / `link.juejin.cn` URLs.

--- a/archive/2026-08-24/ai/Loops-and-Graphs-How-to-Stop-Babysitting-Agents.md
+++ b/archive/2026-08-24/ai/Loops-and-Graphs-How-to-Stop-Babysitting-Agents.md
@@ -64,6 +64,8 @@ cover_image: https://pbs.twimg.com/media/HQaNiAyXMAEIPNz.jpg:large
 
 这时人们会怪模型。也是下一层开始回本的时刻。
 
+![完美循环套在错误形状上](https://pbs.twimg.com/media/HQZ4wCCWgAA5YYj.png)
+
 ## [图是上一层](#the-graph-is-the-layer-above)
 
 **图**是工作的形状：什么跑、什么并行、什么等待、什么根本不跑，以及结果往哪回流。
@@ -110,6 +112,8 @@ Splitter、worker、code node、gate。词汇就这些。
 
 每条边都是 Agent 的图，是在为自己的布线付租金。
 
+![四类节点，其中一类不是模型](https://pbs.twimg.com/media/HQZ5BxZXwAAY8_J.png)
+
 ## [循环真正住在哪里](#where-the-loop-actually-lives)
 
 一句话解开全部混淆：**循环住在节点里，图住在节点之间**。
@@ -141,6 +145,8 @@ Splitter、worker、code node、gate。词汇就这些。
 注意它落在哪里。不在 worker 指令里，而在**决定工作如何被切分**的 brief 里。
 
 已确认的原因变成规则，下一次故障从这一次结束的地方开始。
+
+![两条回路：修正边与学习边](https://pbs.twimg.com/media/HQZ6Gt9WQAAbTUk.png)
 
 ## [退回单元，不是整批](#return-the-unit-not-the-batch)
 
@@ -179,6 +185,8 @@ Splitter、worker、code node、gate。词汇就这些。
 第三行不是「阈值设很高」，而是**通道关闭**——阈值会被调，关闭的通道不会。
 
 在开放的通道里，gate 按顺序读证据：确定性结果 → 本次运行轨迹 → 该节点历史 rollback 频率 → 最后才是模型自评。
+
+![按爆炸半径开门，不按置信度](https://pbs.twimg.com/media/HQZ5mTxXUAANsQt.jpg)
 
 ## [从你自己的工作入手](#where-to-start-on-your-own-work)
 

--- a/docs/superpowers/specs/2026-08-22-translation-format-design.md
+++ b/docs/superpowers/specs/2026-08-22-translation-format-design.md
@@ -93,7 +93,7 @@ Frontmatter 之后按这个顺序，中间空一行：
 - 简体中文。代码块、命令、类名、API、原文图片 URL 不译。
 - 章节标题译成中文，锚点保留原文 slug：`## [引言](#introduction)`。原文没有 slug 时，用标题英文 kebab-case。
 - 术语第一次：`消毒（sanitization）`；后文可只用中文或英文，跟邻近译文习惯。
-- 图片：栅格图（png / jpg / webp）尽量用原文 URL；alt 写成中文说明。不要把掘金 `p9-xtjj-sign` 签名链写进仓库。
+- 图片：栅格图（png / jpg / webp）尽量用原文 URL；alt 写成中文说明。inbox / Jina 正文里的每一张图都要进译文对应段落，不能只留 `cover_image`。X 长文的示意图常在 `pbs.twimg.com/media/`，直抓 x.com HTML 往往只剩头图。不要把掘金 `p9-xtjj-sign` 签名链写进仓库。
 - 同站图示 iframe、内联 SVG、`.svg` 插图：Jina 经常丢掉，HTML 解析要标成 `media:page-visual` / `media:svg` / `section-anim`，转成 `assets/<slug>/` 下的 GIF（有动画）或 PNG（静帧）。译文里不要写 iframe。从 `archive/<date>/<domain>/` 引用时用 `../../../../assets/<slug>/visual-….gif`。
 - 不要把范文里的掘金跳转链 `link.juejin.cn` 学过来。
 

--- a/scripts/article_tools.py
+++ b/scripts/article_tools.py
@@ -34,6 +34,7 @@ HREF_RE = re.compile(r"""\bhref=["']([^"']+)["']""", re.I)
 CSS_URL_RE = re.compile(r"""url\(\s*(["']?)([^)'"]+)\1\s*\)""", re.I)
 CSS_ANIM_PROP_RE = re.compile(r"""(?:^|[;\s"'])animation(?:-[a-z]+)?\s*:""", re.I)
 MEDIA_COMMENT_RE = re.compile(r"<!--\s*media:[^>]+-->")
+IMAGE_MD_RE = re.compile(r"!\[([^\]]*)\]\((https?://[^)\s]+)\)")
 MEDIA_CONTAINER_TAGS = {"section", "figure", "div"}
 MAX_SECTION_SNIPPET_CHARS = 16_384
 MAX_SECTION_STYLE_RATIO = 0.4
@@ -306,6 +307,42 @@ def is_tiny_svg(attrs: dict[str, str | None]) -> bool:
 
 def extract_media_comments(markdown: str) -> list[str]:
     return [match.group(0) for match in MEDIA_COMMENT_RE.finditer(markdown or "")]
+
+
+def image_url_key(url: str) -> str:
+    path = urlparse(url or "").path
+    name = path.rsplit("/", 1)[-1]
+    return re.sub(r":(?:large|orig|small|thumb)$", "", name, flags=re.I)
+
+
+def markdown_image_urls(text: str) -> list[str]:
+    return [match.group(2) for match in IMAGE_MD_RE.finditer(text or "")]
+
+
+def merge_inline_images(target: str, source: str) -> str:
+    """Copy markdown images from source that target is missing, after the matching prior paragraph."""
+    if not source:
+        return target or ""
+    out = target or ""
+    existing = {image_url_key(url) for url in markdown_image_urls(out)}
+    last = 0
+    for match in IMAGE_MD_RE.finditer(source):
+        url = match.group(2)
+        key = image_url_key(url)
+        if not key or key in existing:
+            last = match.end()
+            continue
+        before = source[last : match.start()]
+        needle = last_paragraph_needle(before)
+        snippet = match.group(0)
+        if needle and needle in out:
+            at = out.index(needle) + len(needle)
+            out = out[:at].rstrip() + "\n\n" + snippet + "\n\n" + out[at:].lstrip()
+        else:
+            out = out.rstrip() + "\n\n" + snippet + "\n"
+        existing.add(key)
+        last = match.end()
+    return out
 
 
 def last_paragraph_needle(text: str) -> str:
@@ -854,6 +891,7 @@ def merge_html_enrichment(article: FetchedArticle, html_article: FetchedArticle)
             existing.add(comment)
     article.media_comments = comments or None
     article.markdown = place_media_comments(article.markdown or "", html_article.markdown or "")
+    article.markdown = merge_inline_images(article.markdown or "", html_article.markdown or "")
     if html_article.section_snippets and not article.section_snippets:
         article.section_snippets = list(html_article.section_snippets)
     if not article.author:
@@ -905,7 +943,9 @@ def fetch_article(url: str, timeout: int = 45) -> FetchedArticle:
     except (FetchError, HTTPError, URLError, TimeoutError, ssl.SSLError, OSError) as exc:
         errors.append(f"fetch_via_html: {exc}")
     if jina_article and html_article:
-        return merge_html_enrichment(jina_article, html_article)
+        merged = merge_html_enrichment(jina_article, html_article)
+        merged.markdown = merge_inline_images(merged.markdown or "", jina_article.markdown or "")
+        return merged
     if jina_article:
         return jina_article
     if html_article:

--- a/tests/test_article_tools.py
+++ b/tests/test_article_tools.py
@@ -592,6 +592,49 @@ class MergeHtmlEnrichmentTest(unittest.TestCase):
         self.assertEqual(merged.published_at, "2025-12-01")
         self.assertEqual(merged.cover_image, "https://example.com/jina.png")
 
+    def test_merge_keeps_jina_images_html_is_missing(self) -> None:
+        jina = article_tools.FetchedArticle(
+            url="https://x.com/example/status/1",
+            title="T",
+            markdown=(
+                "That is the moment people blame the model.\n\n"
+                "![diagram 1](https://pbs.twimg.com/media/HQZ4wCCWgAA5YYj.png)\n\n"
+                "The graph is the layer above."
+            ),
+            method="jina",
+        )
+        html = article_tools.FetchedArticle(
+            url="https://x.com/example/status/1",
+            title="T",
+            markdown="That is the moment people blame the model.\n\nThe graph is the layer above.",
+            method="html",
+            cover_image="https://pbs.twimg.com/media/HQaNiAyXMAEIPNz.jpg:large",
+        )
+        merged = article_tools.merge_html_enrichment(jina, html)
+        self.assertIn("HQZ4wCCWgAA5YYj.png", merged.markdown)
+        self.assertLess(
+            merged.markdown.index("blame the model"),
+            merged.markdown.index("HQZ4wCCWgAA5YYj.png"),
+        )
+        self.assertLess(
+            merged.markdown.index("HQZ4wCCWgAA5YYj.png"),
+            merged.markdown.index("The graph is the layer above"),
+        )
+
+    def test_merge_copies_source_images_into_image_poor_target(self) -> None:
+        target = "That is the moment people blame the model.\n\nThe graph is the layer above."
+        source = (
+            "That is the moment people blame the model.\n\n"
+            "![diagram 1](https://pbs.twimg.com/media/HQZ4wCCWgAA5YYj.png)\n\n"
+            "The graph is the layer above."
+        )
+        merged = article_tools.merge_inline_images(target, source)
+        self.assertIn("HQZ4wCCWgAA5YYj.png", merged)
+        self.assertLess(
+            merged.index("blame the model"),
+            merged.index("HQZ4wCCWgAA5YYj.png"),
+        )
+
 
 class InboxGitAddTest(unittest.TestCase):
     def test_paths_omit_missing_assets(self) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
原文 X 长文有 4 张正文示意图，译文之前只留了头图。

**已补图（按原文顺序）：**
1. 完美循环套在错误形状上
2. 四类节点，其中一类不是模型
3. 两条回路：修正边与学习边
4. 按爆炸半径开门，不按置信度

**原因：** 直抓 `x.com` HTML 只有 `og:image` 头图，示意图由 Jina 从文章正文抽出。当时 inbox 走了 HTML 路径，译文只抄了封面。

**流水线修复：** `merge_html_enrichment` / `fetch_article` 会把 Jina 里有、HTML 里没有的 markdown 图片按段落插回。技能与格式说明改为：必须带上 inbox 里每一张栅格图，不能只留 `cover_image`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

