### PR TITLE
fix: 补回「可验证领域」正文图，并修复 X Article 抓取丢图

### DIFF
--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -141,7 +141,7 @@ Omit any header line you cannot fill. Do not use `[原文链接](URL)`.
 ## Body rules
 
 - Simplified Chinese, **polished to the voice table above**. Keep code, commands, API names, and original raster image URLs (`png` / `jpg` / `webp`). Same-origin diagram iframes and SVG (inline or `.svg`) must be converted into `assets/<slug>/` GIF or PNG; GitHub cannot show those iframes, and Jina drops them. From `archive/<date>/<domain>/` use `../../../../assets/<slug>/visual-….gif`.
-- Copy **every** inbox raster diagram into the Chinese post at the matching section — not only `cover_image`. Skip any body image that is the same asset as `文章头图` (do not paste the cover twice). X/Twitter long posts often have 3–6 `pbs.twimg.com/media/…` diagrams that Jina keeps and x.com HTML drops. If the Chinese file only has the header cover, the body diagrams are missing.
+- Copy **every** inbox raster diagram into the Chinese post at the matching section — not only `cover_image`. Skip any body image that is the same asset as `文章头图` (do not paste the cover twice). X/Twitter long posts often have 3–6 `pbs.twimg.com/media/…` diagrams that Jina keeps and x.com HTML drops. **X Articles** (`x.com/i/article/…` linked from a status) are worse: Jina may 403 and HTML often only has the cover — `article_tools` must use `api.fxtwitter.com` so inbox keeps body `MEDIA` blocks and embedded tweets. If the Chinese file only has the header cover, the body diagrams are missing.
 - Headings: `## [引言](#introduction)` — Chinese title, original slug.
 - First use of a term: `消毒（sanitization）`.
 - No `iframe`. No `p9-xtjj-sign` / `link.juejin.cn` URLs.

--- a/archive/2026-08-24/ai/Verifiable-Domains-Will-Eat-The-World.md
+++ b/archive/2026-08-24/ai/Verifiable-Domains-Will-Eat-The-World.md
@@ -28,6 +28,8 @@ cover_image: https://pbs.twimg.com/media/HQYSYeZWAAA8yr0.jpg:large
 
 那个年代最出名的 PowerPoint 恶搞，大概是 Peter Norvig 用幻灯片重述林肯葛底斯堡演说。
 
+![Norvig 的葛底斯堡演说 PowerPoint](https://pbs.twimg.com/media/HQYD4jqXkAAXaNM.png)
+
 林肯那两百七十二个词，每个词与其他词咬合得如此精确，尽管语域抬得很高，却仍有一种自然与完整，让人觉得它只能以这种形态诞生。
 
 Norvig 的 PowerPoint（扭曲）版之所以意外又好笑，是因为我们隐约却深刻地感到：那篇演说构造里那些有说服力的细节，携带着一种干巴巴复述同一堆事实所无法承载的「真」。
@@ -66,11 +68,15 @@ NRSV 译成 “various ways” 的，正是 Wilson 译成 “complicated” 的�
 
 可以想象《希伯来书》作者小心拧着用词旋钮——像 Rick Rubin 在混音台上拧「选词」（polytropos）与「词序」（离开王室之家、受苦、拯救、归家）——直到奥德修斯的形象与耶稣的形象在听众心里对焦，再彼此重叠。
 
+![选词与词序像混音台上的旋钮](https://pbs.twimg.com/media/HQYLrprXYAAsEov.jpg)
+
 当然，作者本可以用别的词开篇，但那就做不到把奥德修斯与耶稣并置的修辞工作。选词是交际行为里有意的一部分；用一个讨人厌的 Claude 腔词说，它是「承重的（load-bearing）」。
 
 ## [AI 水印之争](#the-ai-watermarking-controversy)
 
 上面绕这么大，是为了点出一个多数人凭直觉就懂的事实：选词对文本冲击读者的完整效果事关重大。所以当一位技术界兄弟用数学给我们 mansplain，说 Anthropic 加水印的文本相对无水印文本「没有质量损失」时，我们可能会想回一句：「不，两段措辞不同的文本并不相同，你这绝对的超级宅小丑。回你的火车话题去吧，把品味的事留给有品味的人。」
+
+[嵌入内容（原站 Twitter）](https://x.com/random_walker/status/2089414077286166911)
 
 看看下面这段、一篇还算不错的水印问题解说：
 
@@ -83,6 +89,8 @@ NRSV 译成 “various ways” 的，正是 Wilson 译成 “complicated” 的�
 对我们其余人来说，选词问题与品味、身份、作者性紧密相连，而这些又连着所有权、地位与利润。
 
 这种直觉层面的反应，在下面这则对水印决定的回应里抓得很准。
+
+[嵌入内容（原站 Twitter）](https://x.com/JonTeets005/status/2089824388812005680)
 
 至于对 Anthropic 水印里不那么「靠 vibe」的作者性 / 所有权异议，Ben Thompson 概括得很利落：
 

--- a/docs/superpowers/specs/2026-08-22-translation-format-design.md
+++ b/docs/superpowers/specs/2026-08-22-translation-format-design.md
@@ -94,7 +94,7 @@ Frontmatter 之后按这个顺序，中间空一行：
 - 代码块、命令、类名、API、原文图片 URL 不译。
 - 章节标题译成中文，锚点保留原文 slug：`## [引言](#introduction)`。原文没有 slug 时，用标题英文 kebab-case。
 - 术语第一次：`消毒（sanitization）`；后文可只用中文或英文，跟邻近译文习惯。叙事文里机构名可保留缩写并首次括注。
-- 图片：栅格图（png / jpg / webp）尽量用原文 URL；alt 写成中文说明。inbox / Jina 正文里的示意图都要进译文对应段落，但不能把已作 `文章头图` 的封面再贴一遍。X 长文的示意图常在 `pbs.twimg.com/media/`，直抓 x.com HTML 往往只剩头图。不要把掘金 `p9-xtjj-sign` 签名链写进仓库。
+- 图片：栅格图（png / jpg / webp）尽量用原文 URL；alt 写成中文说明。inbox / Jina 正文里的示意图都要进译文对应段落，但不能把已作 `文章头图` 的封面再贴一遍。X 长文的示意图常在 `pbs.twimg.com/media/`，直抓 x.com HTML 往往只剩头图；**X Article** 正文图在 fxtwitter 的 `content.blocks` / `media_entities` 里，抓取脚本应走 `api.fxtwitter.com`。不要把掘金 `p9-xtjj-sign` 签名链写进仓库。
 - 同站图示 iframe、内联 SVG、`.svg` 插图：Jina 经常丢掉，HTML 解析要标成 `media:page-visual` / `media:svg` / `section-anim`，转成 `assets/<slug>/` 下的 GIF（有动画）或 PNG（静帧）。译文里不要写 iframe。从 `archive/<date>/<domain>/` 引用时用 `../../../../assets/<slug>/visual-….gif`。
 - 不要把范文里的掘金跳转链 `link.juejin.cn` 学过来。
 
@@ -112,7 +112,7 @@ GitHub Markdown **不能**内嵌 YouTube / iframe。仓库里不写 iframe，也
 
 ### 识别
 
-抓取时先用 Jina 拿可读正文，再补一次本地 HTML：媒体标记、`section` 片段、以及 Jina 没有的 `author` / `published_at` / `cover_image`。Jina 失败则只用 HTML。译者按标记落盘、写正文：
+抓取时先用 Jina 拿可读正文，再补一次本地 HTML：媒体标记、`section` 片段、以及 Jina 没有的 `author` / `published_at` / `cover_image`。Jina 失败则只用 HTML。对 X/Twitter **status** URL，额外请求 `api.fxtwitter.com`；若该 status 挂了 **X Article**，以 fxtwitter 的 article blocks（含正文图与嵌入推文）为主。译者按标记落盘、写正文：
 
 ```html
 <!-- media:youtube id="fG8xWTHnlLY" url="https://www.youtube.com/watch?v=fG8xWTHnlLY" -->

--- a/scripts/article_tools.py
+++ b/scripts/article_tools.py
@@ -485,6 +485,256 @@ def fetch_via_jina(url: str, timeout: int = 45) -> FetchedArticle:
     return FetchedArticle(url=url, title=title, markdown=markdown, method="jina")
 
 
+def _parse_twitter_created_at(value: str) -> str | None:
+    raw = (value or "").strip()
+    if not raw:
+        return None
+    for fmt in ("%a %b %d %H:%M:%S %z %Y", "%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(raw, fmt).date().isoformat()
+        except ValueError:
+            continue
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", raw):
+        return raw
+    return None
+
+
+def _normalize_draft_entity_map(raw: object) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            key = str(item.get("key", ""))
+            value = item.get("value")
+            if key and isinstance(value, dict):
+                out[key] = value
+    elif isinstance(raw, dict):
+        for key, value in raw.items():
+            if isinstance(value, dict):
+                out[str(key)] = value
+    return out
+
+
+def _media_urls_by_id(media_entities: object) -> dict[str, str]:
+    by_id: dict[str, str] = {}
+    if not isinstance(media_entities, list):
+        return by_id
+    for item in media_entities:
+        if not isinstance(item, dict):
+            continue
+        mid = str(item.get("media_id") or "")
+        info = item.get("media_info") if isinstance(item.get("media_info"), dict) else {}
+        url = str(info.get("original_img_url") or "").strip()
+        if mid and url:
+            by_id[mid] = url
+    return by_id
+
+
+def cover_image_from_fxtwitter_media(cover_media: object) -> str | None:
+    if not isinstance(cover_media, dict):
+        return None
+    info = cover_media.get("media_info") if isinstance(cover_media.get("media_info"), dict) else {}
+    url = str(info.get("original_img_url") or "").strip()
+    if not url:
+        return None
+    if "pbs.twimg.com/media/" in url and not re.search(r":(?:large|orig|small|thumb)$", url, re.I):
+        url = f"{url}:large"
+    return url
+
+
+def _decorate_draft_text(
+    text: str,
+    style_ranges: list | None,
+    entity_ranges: list | None,
+    entity_map: dict[str, dict],
+) -> str:
+    ops: list[tuple[int, int, str, str, str | None]] = []
+    for rng in style_ranges or []:
+        if not isinstance(rng, dict):
+            continue
+        style = str(rng.get("style") or "").lower()
+        if style == "italic":
+            open_m, close_m = "*", "*"
+        elif style == "bold":
+            open_m, close_m = "**", "**"
+        elif style == "code":
+            open_m, close_m = "`", "`"
+        else:
+            continue
+        start = int(rng.get("offset") or 0)
+        length = int(rng.get("length") or 0)
+        end = start + length
+        if length <= 0 or start < 0 or end > len(text):
+            continue
+        ops.append((start, end, "style", open_m, close_m))
+    for rng in entity_ranges or []:
+        if not isinstance(rng, dict):
+            continue
+        key = str(rng.get("key"))
+        ent = entity_map.get(key) or {}
+        if str(ent.get("type") or "").upper() != "LINK":
+            continue
+        data = ent.get("data") if isinstance(ent.get("data"), dict) else {}
+        url = str(data.get("url") or "").strip()
+        start = int(rng.get("offset") or 0)
+        length = int(rng.get("length") or 0)
+        end = start + length
+        if not url or length <= 0 or start < 0 or end > len(text):
+            continue
+        ops.append((start, end, "link", url, None))
+    # Apply from the end so earlier offsets stay valid; longer spans before shorter.
+    ops.sort(key=lambda item: (-item[0], -(item[1] - item[0])))
+    out = text
+    for start, end, kind, a, b in ops:
+        inner = out[start:end]
+        if kind == "link":
+            out = f"{out[:start]}[{inner}]({a}){out[end:]}"
+        else:
+            out = f"{out[:start]}{a}{inner}{b}{out[end:]}"
+    return out
+
+
+def _atomic_draft_markdown(
+    entity_ranges: list | None,
+    entity_map: dict[str, dict],
+    media_by_id: dict[str, str],
+) -> str:
+    parts: list[str] = []
+    for rng in entity_ranges or []:
+        if not isinstance(rng, dict):
+            continue
+        key = str(rng.get("key"))
+        ent = entity_map.get(key) or {}
+        etype = str(ent.get("type") or "").upper()
+        data = ent.get("data") if isinstance(ent.get("data"), dict) else {}
+        if etype == "MEDIA":
+            for item in data.get("mediaItems") or []:
+                if not isinstance(item, dict):
+                    continue
+                mid = str(item.get("mediaId") or "")
+                url = media_by_id.get(mid)
+                if url:
+                    parts.append(f"![]({url})")
+        elif etype == "TWEET":
+            tid = str(data.get("tweetId") or "")
+            if tid.isdigit():
+                status_url = translation_format.twitter_status_url(tid)
+                parts.append(format_media_comment("twitter", id=tid, url=status_url))
+    return "\n\n".join(parts)
+
+
+def x_article_content_to_markdown(content: object, media_entities: object) -> str:
+    if not isinstance(content, dict):
+        return ""
+    blocks = content.get("blocks") or []
+    if not isinstance(blocks, list):
+        return ""
+    entity_map = _normalize_draft_entity_map(content.get("entityMap"))
+    media_by_id = _media_urls_by_id(media_entities)
+    out_blocks: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        btype = str(block.get("type") or "unstyled")
+        text = str(block.get("text") or "")
+        entity_ranges = block.get("entityRanges") if isinstance(block.get("entityRanges"), list) else []
+        style_ranges = (
+            block.get("inlineStyleRanges") if isinstance(block.get("inlineStyleRanges"), list) else []
+        )
+        if btype == "atomic":
+            atomic = _atomic_draft_markdown(entity_ranges, entity_map, media_by_id)
+            if atomic:
+                out_blocks.append(atomic)
+            continue
+        decorated = _decorate_draft_text(text, style_ranges, entity_ranges, entity_map)
+        if btype == "header-one":
+            out_blocks.append(f"# {decorated}")
+        elif btype == "header-two":
+            out_blocks.append(f"## {decorated}")
+        elif btype == "header-three":
+            out_blocks.append(f"### {decorated}")
+        elif btype == "blockquote":
+            lines = decorated.split("\n")
+            out_blocks.append("\n".join(f"> {line}" if line.strip() else ">" for line in lines))
+        elif btype == "unordered-list-item":
+            out_blocks.append(f"- {decorated}")
+        elif btype == "ordered-list-item":
+            out_blocks.append(f"1. {decorated}")
+        elif btype == "code-block":
+            out_blocks.append(f"```\n{text}\n```")
+        elif decorated.strip():
+            out_blocks.append(decorated)
+    return ("\n\n".join(out_blocks).strip() + "\n") if out_blocks else ""
+
+
+def strip_cover_duplicate_images(markdown: str, cover_url: str | None) -> str:
+    cover_key = image_url_key(cover_url or "")
+    if not cover_key:
+        return markdown or ""
+
+    def _drop(match: re.Match[str]) -> str:
+        return "" if image_url_key(match.group(2)) == cover_key else match.group(0)
+
+    cleaned = IMAGE_MD_RE.sub(_drop, markdown or "")
+    return re.sub(r"\n{3,}", "\n\n", cleaned).strip() + ("\n" if cleaned.strip() else "")
+
+
+def fetch_via_fxtwitter(url: str, timeout: int = 45) -> FetchedArticle:
+    """Fetch an X/Twitter status via FixupX/fxtwitter API (needed for X Articles)."""
+    status_id = translation_format.twitter_status_from_url(url)
+    if not status_id:
+        raise FetchError("Not a Twitter/X status URL")
+    _, body = _http_get(f"https://api.fxtwitter.com/status/{status_id}", timeout=timeout)
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise FetchError(f"fxtwitter returned non-JSON: {exc}") from exc
+    tweet = payload.get("tweet") if isinstance(payload, dict) else None
+    if not isinstance(tweet, dict):
+        tweet = payload if isinstance(payload, dict) else None
+    if not isinstance(tweet, dict):
+        raise FetchError("fxtwitter response missing tweet")
+    author_obj = tweet.get("author") if isinstance(tweet.get("author"), dict) else {}
+    author_name = str(author_obj.get("name") or author_obj.get("screen_name") or "").strip() or None
+    published_at = _parse_twitter_created_at(str(tweet.get("created_at") or ""))
+    article = tweet.get("article")
+    if isinstance(article, dict) and article.get("content"):
+        title = str(article.get("title") or "").strip() or f"X Article {status_id}"
+        markdown = x_article_content_to_markdown(
+            article.get("content"),
+            article.get("media_entities") or [],
+        )
+        cover = cover_image_from_fxtwitter_media(article.get("cover_media"))
+        markdown = strip_cover_duplicate_images(markdown, cover)
+        if len(markdown.strip()) < 80:
+            raise FetchError("fxtwitter article returned too little text")
+        markdown = inject_youtube_comments(markdown.strip())
+        comments = extract_media_comments(markdown)
+        return FetchedArticle(
+            url=url,
+            title=title,
+            markdown=markdown,
+            method="fxtwitter-article",
+            author=author_name,
+            published_at=published_at,
+            cover_image=cover,
+            media_comments=comments or None,
+        )
+    text = str(tweet.get("text") or tweet.get("raw_text") or "").strip()
+    if len(text) < 40:
+        raise FetchError("fxtwitter status returned too little text")
+    title = text.split("\n", 1)[0][:80] or f"Tweet {status_id}"
+    return FetchedArticle(
+        url=url,
+        title=title,
+        markdown=text + "\n",
+        method="fxtwitter",
+        author=author_name,
+        published_at=published_at,
+    )
+
+
 def _attr_html(attrs: list[tuple[str, str | None]]) -> str:
     parts = []
     for key, value in attrs:
@@ -934,6 +1184,12 @@ def fetch_article(url: str, timeout: int = 45) -> FetchedArticle:
     errors: list[str] = []
     jina_article: FetchedArticle | None = None
     html_article: FetchedArticle | None = None
+    fx_article: FetchedArticle | None = None
+    if translation_format.twitter_status_from_url(url):
+        try:
+            fx_article = fetch_via_fxtwitter(url, timeout=timeout)
+        except (FetchError, HTTPError, URLError, TimeoutError, ssl.SSLError, OSError, json.JSONDecodeError) as exc:
+            errors.append(f"fetch_via_fxtwitter: {exc}")
     try:
         jina_article = fetch_via_jina(url, timeout=timeout)
     except (FetchError, HTTPError, URLError, TimeoutError, ssl.SSLError, OSError) as exc:
@@ -942,14 +1198,37 @@ def fetch_article(url: str, timeout: int = 45) -> FetchedArticle:
         html_article = fetch_via_html(url, timeout=timeout)
     except (FetchError, HTTPError, URLError, TimeoutError, ssl.SSLError, OSError) as exc:
         errors.append(f"fetch_via_html: {exc}")
+    # X Articles: body MEDIA lives in fxtwitter JSON; x.com HTML/Jina usually miss it.
+    if fx_article and fx_article.method == "fxtwitter-article":
+        if html_article:
+            return merge_html_enrichment(fx_article, html_article)
+        return fx_article
     if jina_article and html_article:
         merged = merge_html_enrichment(jina_article, html_article)
         merged.markdown = merge_inline_images(merged.markdown or "", jina_article.markdown or "")
+        if fx_article:
+            merged.markdown = merge_inline_images(merged.markdown or "", fx_article.markdown or "")
         return merged
     if jina_article:
+        if fx_article:
+            jina_article.markdown = merge_inline_images(
+                jina_article.markdown or "", fx_article.markdown or ""
+            )
         return jina_article
     if html_article:
+        if fx_article:
+            html_article.markdown = merge_inline_images(
+                html_article.markdown or "", fx_article.markdown or ""
+            )
+            if not html_article.cover_image and fx_article.cover_image:
+                html_article.cover_image = fx_article.cover_image
+            if not html_article.author and fx_article.author:
+                html_article.author = fx_article.author
+            if not html_article.published_at and fx_article.published_at:
+                html_article.published_at = fx_article.published_at
         return html_article
+    if fx_article:
+        return fx_article
     raise FetchError("All fetch methods failed: " + " | ".join(errors))
 
 

--- a/tests/test_article_tools.py
+++ b/tests/test_article_tools.py
@@ -636,6 +636,114 @@ class MergeHtmlEnrichmentTest(unittest.TestCase):
         )
 
 
+class FxTwitterArticleTest(unittest.TestCase):
+    def test_x_article_content_keeps_body_media_and_tweet_embeds(self) -> None:
+        content = {
+            "blocks": [
+                {
+                    "type": "unstyled",
+                    "text": "Norvig spoofed the Gettysburg address.",
+                    "entityRanges": [],
+                    "inlineStyleRanges": [],
+                },
+                {
+                    "type": "atomic",
+                    "text": " ",
+                    "entityRanges": [{"key": 0, "length": 1, "offset": 0}],
+                    "inlineStyleRanges": [],
+                },
+                {
+                    "type": "unstyled",
+                    "text": "Then a reply captured the vibe.",
+                    "entityRanges": [],
+                    "inlineStyleRanges": [],
+                },
+                {
+                    "type": "atomic",
+                    "text": " ",
+                    "entityRanges": [{"key": 1, "length": 1, "offset": 0}],
+                    "inlineStyleRanges": [],
+                },
+                {
+                    "type": "header-two",
+                    "text": "Load-bearing complications",
+                    "entityRanges": [],
+                    "inlineStyleRanges": [],
+                },
+                {
+                    "type": "unstyled",
+                    "text": "See Ellen Aitken for the link.",
+                    "entityRanges": [{"key": 2, "length": 12, "offset": 4}],
+                    "inlineStyleRanges": [{"style": "Italic", "offset": 21, "length": 3}],
+                },
+            ],
+            "entityMap": [
+                {
+                    "key": "0",
+                    "value": {
+                        "type": "MEDIA",
+                        "data": {
+                            "mediaItems": [{"mediaId": "111", "mediaCategory": "DraftTweetImage"}]
+                        },
+                    },
+                },
+                {
+                    "key": "1",
+                    "value": {"type": "TWEET", "data": {"tweetId": "2089414077286166911"}},
+                },
+                {
+                    "key": "2",
+                    "value": {
+                        "type": "LINK",
+                        "data": {"url": "https://en.wikipedia.org/wiki/Ellen_Bradshaw_Aitken"},
+                    },
+                },
+            ],
+        }
+        media_entities = [
+            {
+                "media_id": "111",
+                "media_info": {
+                    "original_img_url": "https://pbs.twimg.com/media/HQYD4jqXkAAXaNM.png",
+                },
+            }
+        ]
+        markdown = article_tools.x_article_content_to_markdown(content, media_entities)
+        self.assertIn("HQYD4jqXkAAXaNM.png", markdown)
+        self.assertIn('media:twitter id="2089414077286166911"', markdown)
+        self.assertIn("## Load-bearing complications", markdown)
+        self.assertIn(
+            "[Ellen Aitken](https://en.wikipedia.org/wiki/Ellen_Bradshaw_Aitken)",
+            markdown,
+        )
+        self.assertIn("*the*", markdown)
+        self.assertLess(markdown.index("Gettysburg"), markdown.index("HQYD4jqXkAAXaNM.png"))
+        self.assertLess(markdown.index("HQYD4jqXkAAXaNM.png"), markdown.index("captured the vibe"))
+
+    def test_cover_image_gets_large_suffix(self) -> None:
+        url = article_tools.cover_image_from_fxtwitter_media(
+            {
+                "media_info": {
+                    "original_img_url": "https://pbs.twimg.com/media/HQYSYeZWAAA8yr0.jpg",
+                }
+            }
+        )
+        self.assertEqual(url, "https://pbs.twimg.com/media/HQYSYeZWAAA8yr0.jpg:large")
+
+    def test_strip_cover_duplicate_images(self) -> None:
+        body = (
+            "Intro.\n\n"
+            "![cover again](https://pbs.twimg.com/media/HQYSYeZWAAA8yr0.jpg)\n\n"
+            "More.\n\n"
+            "![diagram](https://pbs.twimg.com/media/HQYD4jqXkAAXaNM.png)\n"
+        )
+        cleaned = article_tools.strip_cover_duplicate_images(
+            body, "https://pbs.twimg.com/media/HQYSYeZWAAA8yr0.jpg:large"
+        )
+        self.assertNotIn("HQYSYeZWAAA8yr0", cleaned)
+        self.assertIn("HQYD4jqXkAAXaNM.png", cleaned)
+
+
 class InboxGitAddTest(unittest.TestCase):
     def test_paths_omit_missing_assets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

[Verifiable Domains Will Eat The World](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-24/ai/Verifiable-Domains-Will-Eat-The-World.md) 原文是 **X Article**（status 挂 `i/article/…`），不是普通长推。直抓 x.com HTML / Jina 往往只有封面；正文示意图与嵌入推文在 `api.fxtwitter.com` 的 `article.content.blocks` + `media_entities` 里。

## 修复

- 译文补回两张正文图（Norvig PPT、混音台旋钮）与两则 Twitter 嵌入
- `article_tools.fetch_article` 对 X/Twitter status 走 fxtwitter；有 X Article 时以 article blocks 为主
- 技能 / 格式说明补充：X Article 必须用 fxtwitter，否则 inbox 会只剩头图

## 验证

- `python3 -m unittest tests.test_article_tools`
- `validate_translation` 通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

