### PR TITLE
docs: 合入译文时必须关掉相关 inbox PR

### DIFF
--- a/.github/ISSUE_TEMPLATE/translate-article.yml
+++ b/.github/ISSUE_TEMPLATE/translate-article.yml
@@ -8,7 +8,7 @@ body:
       value: |
         一篇文章：填原文链接，可选填中文标题。
         多篇文章：不要共用一个标题，在「更多文章」里每行一篇，写成 `链接` 或 `链接 | 中文标题`。
-        提交后 GitHub Action 会抓原文并开 inbox PR；若仓库配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。
+        提交后 GitHub Action 会抓原文并开 **inbox PR**（只含英文，**不要合入**；译文合入、Issue 关闭后会自动关掉）。若仓库配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。
   - type: input
     id: url
     attributes:

--- a/.github/agents/article-translator.agent.md
+++ b/.github/agents/article-translator.agent.md
@@ -16,7 +16,7 @@ When assigned an issue or pull request:
 2. Prefer inbox source files — GitHub Actions fetches them because you may not be able to browse the live page.
 3. If inbox files are missing, run `python scripts/article_tools.py --url <URL> --outdir _inbox`.
 4. Run `python scripts/capture_media.py --inbox _inbox --repo-root .` when media comments exist.
-5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub). Use inbox `title_zh` as `title` when present. Update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source. The translation PR body must include `Closes #<issue>`. Close the Action inbox PR without merging it.
+5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub). Use inbox `title_zh` as `title` when present. Update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source. The translation PR body must include `Closes #<issue>`. **Never merge** the Action inbox PR (`translate/issue-<n>`, title `Translate: …`). Close it without merging as soon as the translation PR exists; when the user asks to merge the translation, merge that PR **and** close any still-open related inbox PR for the same issue.
 6. **Voice checklist before opening/updating the PR** (skill § Voice and polish): pick the row for this article type; rewrite any paragraph that still reads like DeepL / stacked「的」/ stiff「当…的时候」; founder essays need rhythm and cold humor, not press-release Chinese; tech posts need engineer cadence, not textbook tone.
 7. Do not change unrelated translations.
 

--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -181,7 +181,29 @@ Delete the matching `_inbox/*.source.md`. Keep `assets/<slug>/` GIFs that the tr
 
 ## Done
 
-Open or update a pull request with the translation, README, and any `assets/<slug>/` files. The PR body **must** include `Closes #<issue>` so GitHub closes the `[Translate]` issue when this PR merges. Do **not** put `Closes #<issue>` on the Action inbox PR (that one is only English `_inbox/`). After the translation PR exists, close the leftover inbox PR without merging it.
+Open or update a pull request with the translation, README, and any `assets/<slug>/` files. The PR body **must** include `Closes #<issue>` so GitHub closes the `[Translate]` issue when this PR merges. Do **not** put `Closes #<issue>` on the Action inbox PR (that one is only English `_inbox/`).
+
+### 两类 PR（必读）
+
+| 类型 | 典型分支 / 标题 | 合不合入 |
+| --- | --- | --- |
+| **译文 PR** | `cursor/translate-…`，标题「翻译：…」 | **合入**；正文写 `Closes #<issue>` |
+| **inbox PR** | `translate/issue-<n>`，标题 `Translate: …`，作者多为 `github-actions` | **永不合入**；只作英文原文暂存 |
+
+译文 PR 一开出来（或 CI 通过、准备可审）时，立刻关掉同 Issue 的 inbox PR，**不要等用户催**。用户说「合入 / 合并」时：
+
+1. 合入译文 PR（merge）
+2. **马上**关掉仍打开的相关 inbox PR：`translate/issue-<同一 issue 号>`，以及正文写 `Related to #<issue>` 的 Action PR
+3. 确认 `[Translate]` Issue 已因 `Closes #` 关闭
+
+找法示例：
+
+```bash
+gh pr list --repo OWNER/REPO --state open --json number,title,headRefName,body \
+  --jq '.[] | select(.headRefName=="translate/issue-N" or (.body|test("Related to #N")))'
+# 关掉（不合入）：
+gh pr close <inbox-pr-number> --repo OWNER/REPO
+```
 
 Validate before you finish:
 

--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -190,20 +190,21 @@ Open or update a pull request with the translation, README, and any `assets/<slu
 | **译文 PR** | `cursor/translate-…`，标题「翻译：…」 | **合入**；正文写 `Closes #<issue>` |
 | **inbox PR** | `translate/issue-<n>`，标题 `Translate: …`，作者多为 `github-actions` | **永不合入**；只作英文原文暂存 |
 
-译文 PR 一开出来（或 CI 通过、准备可审）时，立刻关掉同 Issue 的 inbox PR，**不要等用户催**。用户说「合入 / 合并」时：
+译文 PR 一开出来（或 CI 通过、准备可审）时，立刻关掉同 Issue 的 inbox PR，**不要等用户催**。Issue 因 `Closes #` 关闭时，Action `Close translation inbox PR` 也会自动关 inbox PR；agent 仍应主动关，别只靠自动化。用户说「合入 / 合并」时：
 
 1. 合入译文 PR（merge）
 2. **马上**关掉仍打开的相关 inbox PR：`translate/issue-<同一 issue 号>`，以及正文写 `Related to #<issue>` 的 Action PR
 3. 确认 `[Translate]` Issue 已因 `Closes #` 关闭
 
-找法示例：
+找法 / 关掉（不合入）：
 
 ```bash
-gh pr list --repo OWNER/REPO --state open --json number,title,headRefName,body \
-  --jq '.[] | select(.headRefName=="translate/issue-N" or (.body|test("Related to #N")))'
-# 关掉（不合入）：
+# 按分支（把 N 换成 issue 号）
+gh pr list --repo OWNER/REPO --head "translate/issue-N" --state open --json number,url
 gh pr close <inbox-pr-number> --repo OWNER/REPO
 ```
+
+Cursor Cloud agent 若不能用 `gh pr close` 写操作，用 `ManagePullRequest`：`action=set_pr_status`，`status=closed`，传入 inbox PR 的 `pr_url`。
 
 Validate before you finish:
 

--- a/.github/workflows/close-inbox-pr.yml
+++ b/.github/workflows/close-inbox-pr.yml
@@ -1,0 +1,53 @@
+# Close Action inbox PRs after the translation lands.
+# When a [Translate] issue closes (usually via Closes #<n> on the translation PR),
+# close the leftover inbox PR (translate/issue-<n>) without merging it.
+name: Close translation inbox PR
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  close-inbox:
+    if: >
+      startsWith(github.event.issue.title, '[Translate]') ||
+      contains(join(github.event.issue.labels.*.name, ','), 'translate') ||
+      contains(join(github.event.issue.labels.*.name, ','), 'translation-queued')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close translate/issue-<n> inbox PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          BRANCH="translate/issue-${ISSUE_NUMBER}"
+          PR_JSON=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+            --json number,url,title --jq '.[0] // empty')
+          if [[ -n "$PR_JSON" ]]; then
+            NUM=$(jq -r '.number' <<<"$PR_JSON")
+            URL=$(jq -r '.url' <<<"$PR_JSON")
+            echo "Closing inbox PR #${NUM} (${URL}) for closed issue #${ISSUE_NUMBER}."
+            gh pr close "$NUM" --repo "$REPO" \
+              --comment "Closing inbox PR: #${ISSUE_NUMBER} closed after the translation PR. Inbox PRs are never merged."
+            exit 0
+          fi
+          mapfile -t CANDIDATES < <(
+            gh pr list --repo "$REPO" --state open --limit 50 \
+              --json number,headRefName,body \
+              --jq ".[] | select(.headRefName|startswith(\"translate/issue-\")) | select(.body|test(\"Related to #${ISSUE_NUMBER}\\\\b\")) | .number"
+          )
+          if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
+            echo "No open inbox PR for issue #${ISSUE_NUMBER}."
+            exit 0
+          fi
+          for num in "${CANDIDATES[@]}"; do
+            echo "Closing inbox PR #${num} (Related to #${ISSUE_NUMBER})."
+            gh pr close "$num" --repo "$REPO" \
+              --comment "Closing inbox PR: translation for #${ISSUE_NUMBER} is done. Inbox PRs are never merged."
+          done

--- a/.github/workflows/translate-article.yml
+++ b/.github/workflows/translate-article.yml
@@ -132,7 +132,7 @@ jobs:
           EOF
           )
           if [[ -n "$ISSUE_NUMBER" ]]; then
-            PR_BODY+=$'\n\n'"Related to #${ISSUE_NUMBER}. Do not merge this inbox PR to close the issue — the translation PR must say \`Closes #${ISSUE_NUMBER}\`."
+            PR_BODY+=$'\n\n'"Related to #${ISSUE_NUMBER}. **Do not merge this inbox PR.** When the translation PR (\`Closes #${ISSUE_NUMBER}\`) is opened or merged, close this PR without merging."
           fi
           PR_URL=$(gh pr list --head "$BRANCH" --json url --jq '.[0].url' || true)
           if [[ -z "$PR_URL" ]]; then

--- a/.github/workflows/translate-article.yml
+++ b/.github/workflows/translate-article.yml
@@ -203,7 +203,7 @@ jobs:
               "target_repo": "${GITHUB_REPOSITORY}",
               "base_branch": "${BRANCH}",
               "custom_agent": "article-translator",
-              "custom_instructions": "Translate every _inbox/*.source.md file using .github/skills/translating-articles/SKILL.md. Update README.md and delete the inbox sources when done."
+              "custom_instructions": "Translate every _inbox/*.source.md file using .github/skills/translating-articles/SKILL.md. Update README.md and delete the inbox sources when done. Translation PR body must include Closes #<issue>. Never merge the Action inbox PR (branch translate/issue-<n>, title Translate: …); close that inbox PR without merging as soon as your translation PR exists, and again when the translation is merged."
             }
           }
           EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,4 +6,4 @@ When the user (or a GitHub issue) provides an article URL, follow `.github/skill
 
 Use the Copilot custom agent `.github/agents/article-translator.agent.md` when working from GitHub.com.
 
-Each `[Translate]` issue yields two PRs: an Action **inbox** PR (`translate/issue-<n>`, English only — never merge; close it) and a **translation** PR (`Closes #<n>` — merge this). When merging the translation, always close the related inbox PR.
+Each `[Translate]` issue yields two PRs: an Action **inbox** PR (`translate/issue-<n>`, English only — never merge; close it) and a **translation** PR (`Closes #<n>` — merge this). When merging the translation, always close the related inbox PR. Closing the issue also triggers `.github/workflows/close-inbox-pr.yml` to close that inbox PR automatically.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,5 @@ This repository publishes Simplified Chinese translations of English software ar
 When the user (or a GitHub issue) provides an article URL, follow `.github/skills/translating-articles/SKILL.md`. Prefer `_inbox/*.source.md` if the GitHub Action already fetched the page. Output must match `docs/superpowers/specs/2026-08-22-translation-format-design.md`.
 
 Use the Copilot custom agent `.github/agents/article-translator.agent.md` when working from GitHub.com.
+
+Each `[Translate]` issue yields two PRs: an Action **inbox** PR (`translate/issue-<n>`, English only — never merge; close it) and a **translation** PR (`Closes #<n>` — merge this). When merging the translation, always close the related inbox PR.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 1. **GitHub：** 打开 [翻译文章](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml)。一篇填链接和可选中文标题；多篇在「更多文章」里每行 `链接` 或 `链接 | 中文标题`。
 2. **Cursor：** 在对话里直接贴网址（可带中文标题）。Agent 先跑 `python3 scripts/queue_translation.py --create --url …` 创建同样格式的 Issue，再写译文。不要只在本地改文件、不建 Issue。
 
-提交 Issue 后 Action 会抓原文、开 inbox PR。仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。Cursor 对话里贴的链接，由当前 agent 在建 Issue 之后把译文写完。
+提交 Issue 后 Action 会抓原文、开 **inbox PR**（`translate/issue-<n>`，只含英文 `_inbox/`，**不要合入**）。真正合入的是带中文译文、`Closes #<issue>` 的译文 PR；合入译文时顺手关掉同 Issue 的 inbox PR。仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。Cursor 对话里贴的链接，由当前 agent 在建 Issue 之后把译文写完。
 
 重试：关掉再打开 Issue，或补上 `translate` 标签。也可以在 **Actions → Translate article** 里直接跑。
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 | 路径 | 作用 |
 | --- | --- |
 | `.github/workflows/translate-article.yml` | 抓取链接，写入 `_inbox/`，开 inbox PR |
+| `.github/workflows/close-inbox-pr.yml` | Issue 关闭后自动关掉 `translate/issue-<n>` inbox PR（不合入） |
 | `.github/agents/article-translator.agent.md` | Copilot 自定义翻译 agent |
 | `.github/skills/translating-articles/SKILL.md` | Cursor / Copilot 共用的翻译技能 |
 | `scripts/article_tools.py` | 抽 URL、Jina 正文、HTML 媒体/meta 合并 |

--- a/docs/translating-articles.md
+++ b/docs/translating-articles.md
@@ -11,7 +11,7 @@ Two entry points, one Issue format:
 1. **GitHub:** open **[翻译文章](../../issues/new?template=translate-article.yml)**. One article: URL + optional Chinese title. Several articles: `URL` or `URL | 中文标题` per line in **更多文章**.
 2. **Cursor:** paste URL(s) in chat. The agent runs `python3 scripts/queue_translation.py --create --url …` to open the same Issue, then writes the translation if Copilot does not.
 
-The Action fetches `_inbox/` after the Issue is opened and opens an **inbox PR** (`translate/issue-<n>`). That PR is only English source; it must **not** say `Closes #<issue>`, and it must **never be merged**. The **translation PR** closes the Issue with `Closes #<issue>`. As soon as the translation PR exists—and again when that PR is merged—**close** the related inbox PR without merging it. If `COPILOT_ASSIGN_TOKEN` is set, the Action also assigns Copilot.
+The Action fetches `_inbox/` after the Issue is opened and opens an **inbox PR** (`translate/issue-<n>`). That PR is only English source; it must **not** say `Closes #<issue>`, and it must **never be merged**. The **translation PR** closes the Issue with `Closes #<issue>`. As soon as the translation PR exists—and again when that PR is merged—**close** the related inbox PR without merging it. When the Issue closes, workflow `Close translation inbox PR` also closes `translate/issue-<n>` automatically. If `COPILOT_ASSIGN_TOKEN` is set, the Action also assigns Copilot.
 
 To retry, reopen the issue or add the `translate` label. The issue title should start with `[Translate]`.
 
@@ -34,5 +34,6 @@ Copilot assignment needs a **user-to-server** token, not `GITHUB_TOKEN`. See [Us
 | `.github/agents/article-translator.agent.md` | Copilot custom agent |
 | `.github/skills/translating-articles/SKILL.md` | Shared translation skill |
 | `.github/workflows/translate-article.yml` | Fetch URLs and open the inbox PR |
+| `.github/workflows/close-inbox-pr.yml` | Close `translate/issue-<n>` when the `[Translate]` issue closes |
 | `scripts/article_tools.py` | URL extract + Jina text + HTML media/meta merge |
 | `scripts/capture_media.py` | Convert inbox media ≤15s (video / YouTube / section) into `assets/<slug>/` GIFs |

--- a/docs/translating-articles.md
+++ b/docs/translating-articles.md
@@ -11,7 +11,7 @@ Two entry points, one Issue format:
 1. **GitHub:** open **[翻译文章](../../issues/new?template=translate-article.yml)**. One article: URL + optional Chinese title. Several articles: `URL` or `URL | 中文标题` per line in **更多文章**.
 2. **Cursor:** paste URL(s) in chat. The agent runs `python3 scripts/queue_translation.py --create --url …` to open the same Issue, then writes the translation if Copilot does not.
 
-The Action fetches `_inbox/` after the Issue is opened and opens an inbox PR. That PR is only English source; it must **not** say `Closes #<issue>`. The translation PR closes the Issue. If `COPILOT_ASSIGN_TOKEN` is set, the Action also assigns Copilot.
+The Action fetches `_inbox/` after the Issue is opened and opens an **inbox PR** (`translate/issue-<n>`). That PR is only English source; it must **not** say `Closes #<issue>`, and it must **never be merged**. The **translation PR** closes the Issue with `Closes #<issue>`. As soon as the translation PR exists—and again when that PR is merged—**close** the related inbox PR without merging it. If `COPILOT_ASSIGN_TOKEN` is set, the Action also assigns Copilot.
 
 To retry, reopen the issue or add the `translate` label. The issue title should start with `[Translate]`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把「合入译文时关掉相关 inbox PR」写进流程，并按 CR 补上强制手段。

## 改动

- 技能 / agent / README / AGENTS / docs：两类 PR 对照；合入译文时关 inbox
- Action inbox PR 文案：永不合入，译文开出或合入后关掉
- **CR 跟进：** `close-inbox-pr.yml` — `[Translate]` Issue 关闭时自动 `gh pr close` 掉 `translate/issue-<n>`
- Copilot `custom_instructions` 与 Cursor `ManagePullRequest` 关闭路径
- Issue 模板一句说明 inbox 不要合入

## CR

独立评审：文档对齐需求；Important 为「仅靠约定仍会残留」——已用 workflow 自动关闭补上。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b39b52c-b32d-4afb-9a41-d9a01d7ccc3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

