### PR TITLE
docs: 更新 README 用法说明并改用中文目录标题

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,14 @@
 1. **GitHub：** 打开 [翻译文章](https://github.com/lihenair/techtranslate/issues/new?template=translate-article.yml)。一篇填链接和可选中文标题；多篇在「更多文章」里每行 `链接` 或 `链接 | 中文标题`。
 2. **Cursor：** 在对话里直接贴网址（可带中文标题）。Agent 先跑 `python3 scripts/queue_translation.py --create --url …` 创建同样格式的 Issue，再写译文。不要只在本地改文件、不建 Issue。
 
-提交 Issue 后 Action 会抓原文、开 **inbox PR**（`translate/issue-<n>`，只含英文 `_inbox/`，**不要合入**）。真正合入的是带中文译文、`Closes #<issue>` 的译文 PR；合入译文时顺手关掉同 Issue 的 inbox PR。仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。Cursor 对话里贴的链接，由当前 agent 在建 Issue 之后把译文写完。
+每个 Issue 会对应两类 PR：
+
+| 类型 | 分支 / 标题 | 要不要合入 |
+| --- | --- | --- |
+| **inbox PR** | `translate/issue-<n>`，标题 `Translate: …`，只含英文 `_inbox/` | **不要合入**，关掉即可 |
+| **译文 PR** | 中文译文，正文写 `Closes #<issue>` | **合入这个** |
+
+Issue 关闭后，工作流 `close-inbox-pr.yml` 会自动关掉同号 inbox PR。仓库若配置了 `COPILOT_ASSIGN_TOKEN`，会自动指派 Copilot 写译文。Cursor 对话里贴的链接，由当前 agent 在建 Issue 之后把译文写完。
 
 重试：关掉再打开 Issue，或补上 `translate` 标签。也可以在 **Actions → Translate article** 里直接跑。
 
@@ -23,6 +30,7 @@
 | --- | --- |
 | `.github/workflows/translate-article.yml` | 抓取链接，写入 `_inbox/`，开 inbox PR |
 | `.github/workflows/close-inbox-pr.yml` | Issue 关闭后自动关掉 `translate/issue-<n>` inbox PR（不合入） |
+| `.github/workflows/article-tools.yml` | 脚本、格式校验和归档目录的单元测试 |
 | `.github/agents/article-translator.agent.md` | Copilot 自定义翻译 agent |
 | `.github/skills/translating-articles/SKILL.md` | Cursor / Copilot 共用的翻译技能 |
 | `scripts/article_tools.py` | 抽 URL、Jina 正文、HTML 媒体/meta 合并 |
@@ -51,7 +59,7 @@
 - 2026-08-23 [阻止 Agent 忽略指令的 10 种 Claude Code 引导机制](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-23/ai/10-Claude-Code-Steering-Mechanisms-That-Stop-Agents-From-Ignoring-Instructions.md)
 - 2026-08-23 [用 Unsloth 本地微调 Gemma 4](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-23/ai/Fine-tune-Gemma-4-locally-with-Unsloth.md)
 - 2026-08-23 [AI 芯片架构](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-23/ai/AI-Chip-Architectures.md)
-- 2026-08-22 [NoBuzz](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-22/ai/NoBuzz.md)
+- 2026-08-22 [NoBuzz：把 Claude 的腔调译回人话](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-22/ai/NoBuzz.md)
 
 ### 安全
 
@@ -60,30 +68,29 @@
 ### Android
 
 - 2026-08-24 [安卓车机恶意软件](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-24/android/The-invisible-passenger-in-your-car.md)
-- 2021-11-07 [Recomposition-Made-Easy](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Recomposition-Made-Easy.md)
-- 2021-11-07 [CompositionLocal-Made-Easy](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/CompositionLocal-Made-Easy.md)
-- 2021-03-29 [Kotlin Contracts](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Kotlin%20Contract.md)
+- 2021-11-07 [轻松理解 Jetpack Compose 的 Recomposition](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Recomposition-Made-Easy.md)
+- 2021-11-07 [轻松理解 Jetpack Compose 的 CompositionLocal](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/CompositionLocal-Made-Easy.md)
+- 2021-03-29 [Kotlin 合约（Contracts）](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Kotlin%20Contract.md)
 - 2017-08-25 [鼓捣RxAndroid-Part1](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E9%BC%93%E6%8D%A3RxAndroid-Part1.md)
+- 2017-08-25 [用 AnimatedVectorDrawable 做路径形变](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Andro%E4%BD%BF%E7%94%A8AnimatedVectorDrawables%E5%A4%84%E7%90%86%E7%BA%BF%E8%B7%AF%E8%BD%AC%E6%8D%A2.md)
 - 2017-08-25 [地图业务重构](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E5%9C%B0%E5%9B%BE%E4%B8%9A%E5%8A%A1%E9%87%8D%E6%9E%84.md)
+- 2017-08-25 [动画：Jump-through](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Animation-%20Jump-through.md)
 - 2017-08-25 [使用DiffUtil更新RecyclerView的智能方式](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E4%BD%BF%E7%94%A8DiffUtil%E6%9B%B4%E6%96%B0RecyclerView%E7%9A%84%E6%99%BA%E8%83%BD%E6%96%B9%E5%BC%8F.md)
 - 2017-08-25 [何时调整你的网络图片？](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E4%BD%95%E6%97%B6%E8%B0%83%E6%95%B4%E4%BD%A0%E7%9A%84%E7%BD%91%E7%BB%9C%E5%9B%BE%E7%89%87%EF%BC%9F.md)
-- 2017-08-25 [[译]Android架构组件 – 查看ViewModel – 第二部分](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%5B%E8%AF%91%5DAndroid%E6%9E%B6%E6%9E%84%E7%BB%84%E4%BB%B6%20%E2%80%93%20%E6%9F%A5%E7%9C%8BViewModel%20%E2%80%93%20%E7%AC%AC%E4%BA%8C%E9%83%A8%E5%88%86.md)
 - 2017-08-25 [RenderScript](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/RenderScript.md)
-- 2017-08-25 [Kotlin Data Class](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Kotlin%20Data%20Class.md)
-- 2017-08-25 [Extension Function](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Extension%20Function.md)
+- 2017-08-25 [Kotlin 数据类](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Kotlin%20Data%20Class.md)
+- 2017-08-25 [Kotlin 扩展函数](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Extension%20Function.md)
 - 2017-08-25 [DiffUtil是必须的!](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/DiffUtil%E6%98%AF%E5%BF%85%E9%A1%BB%E7%9A%84%21.md)
-- 2017-08-25 [Animation: Jump-through](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Animation-%20Jump-through.md)
-- 2017-08-25 [Andro使用AnimatedVectorDrawables处理线路转换](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Andro%E4%BD%BF%E7%94%A8AnimatedVectorDrawables%E5%A4%84%E7%90%86%E7%BA%BF%E8%B7%AF%E8%BD%AC%E6%8D%A2.md)
 - 2017-08-25 [Android的构建时依赖性修补程序](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%E7%9A%84%E6%9E%84%E5%BB%BA%E6%97%B6%E4%BE%9D%E8%B5%96%E6%80%A7%E4%BF%AE%E8%A1%A5%E7%A8%8B%E5%BA%8F.md)
+- 2017-08-25 [Android架构组件 – 查看ViewModel – 第二部分](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%5B%E8%AF%91%5DAndroid%E6%9E%B6%E6%9E%84%E7%BB%84%E4%BB%B6%20%E2%80%93%20%E6%9F%A5%E7%9C%8BViewModel%20%E2%80%93%20%E7%AC%AC%E4%BA%8C%E9%83%A8%E5%88%86.md)
 - 2017-08-25 [Android架构组件 – 查看Room和LiveData – 第一部分](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%E6%9E%B6%E6%9E%84%E7%BB%84%E4%BB%B6%20%E2%80%93%20%E6%9F%A5%E7%9C%8BRoom%E5%92%8CLiveData%20%E2%80%93%20%E7%AC%AC%E4%B8%80%E9%83%A8%E5%88%86.md)
 - 2017-08-25 [Android架构组件 - 查看Lifecycles - 第3部分](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%E6%9E%B6%E6%9E%84%E7%BB%84%E4%BB%B6%20-%20%E6%9F%A5%E7%9C%8BLifecycles%20-%20%E7%AC%AC3%E9%83%A8%E5%88%86.md)
 - 2017-08-25 [AndroidWeekly248期 源码库与代码](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/AndroidWeekly248%E6%9C%9F%20%E6%BA%90%E7%A0%81%E5%BA%93%E4%B8%8E%E4%BB%A3%E7%A0%81.md)
-- 2016-12-29 [DI101-第一部分](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/DI101-Part1.md)
-- 2016-12-29 [DI101 - 第一部分](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/DI101%20-%20%E7%AC%AC%E4%B8%80%E9%83%A8%E5%88%86.md)
-- 2016-10-27 [Android 7.1 Static Shortcut](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%207.1%E9%9D%99%E6%80%81%E5%BF%AB%E6%8D%B7%E6%96%B9%E5%BC%8F.md)
-- 2016-10-08 [Annotation Processing in Android Studio](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Annotation%20Processing%20in%20Android%20Studio.md)
-- 2016-09-28 [Android support Annotation](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%20support%20Annotation.md)
-- 2016-09-07 [Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!)](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Keeping%20Android%20runtime%20permissions%20from%20cluttering%20your%20app%20%28Headless%20Dialog%20Fragments%21%29.md)
+- 2016-12-29 [DI101：Android 平台依赖注入（第一部分）](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/DI101-Part1.md)
+- 2016-10-27 [Android 7.1 静态快捷方式](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%207.1%E9%9D%99%E6%80%81%E5%BF%AB%E6%8D%B7%E6%96%B9%E5%BC%8F.md)
+- 2016-10-08 [在 Android Studio 里做注解处理](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Annotation%20Processing%20in%20Android%20Studio.md)
+- 2016-09-28 [Android Support 注解](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%20support%20Annotation.md)
+- 2016-09-07 [别让运行时权限把应用搞乱（Headless Dialog Fragment）](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Keeping%20Android%20runtime%20permissions%20from%20cluttering%20your%20app%20%28Headless%20Dialog%20Fragments%21%29.md)
 - 2016-08-30 [异步布局加载](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E5%BC%82%E6%AD%A5%E5%B8%83%E5%B1%80%E5%8A%A0%E8%BD%BD.md)
 - 2016-08-29 [使用Gradle额外属性管理Android依赖版本](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E4%BD%BF%E7%94%A8Gradle%E9%A2%9D%E5%A4%96%E5%B1%9E%E6%80%A7%E7%AE%A1%E7%90%86Android%E4%BE%9D%E8%B5%96%E7%89%88%E6%9C%AC.md)
 - 2016-08-25 [Android原生支持Java8的Lambdas表达式](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Android%E5%8E%9F%E7%94%9F%E6%94%AF%E6%8C%81Java8%E7%9A%84Lambdas%E8%A1%A8%E8%BE%BE%E5%BC%8F.md)
@@ -95,10 +102,10 @@
 - 2016-08-17 [使用Picasso加载图片](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E4%BD%BF%E7%94%A8Picasso%E5%8A%A0%E8%BD%BD%E5%9B%BE%E7%89%87.md)
 - 2016-08-17 [使用Dagger 2进行依赖注入 - API介绍](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E4%BD%BF%E7%94%A8Dagger%202%E8%BF%9B%E8%A1%8C%E4%BE%9D%E8%B5%96%E6%B3%A8%E5%85%A5.md)
 - 2016-08-17 [产品使用Dagger 2——减少方法数](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Dagger%202%20on%20producton%E2%80%94reducing%20methods%20count.md)
+- 2016-08-17 [不再需要 findViewById](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/No%20More%20findViewById.md)
 - 2016-08-17 [Router——一切都在正确的位置 映射功能到应用的组件](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/%E8%B7%AF%E7%94%B1%E5%99%A8.md)
-- 2016-08-17 [No More findViewById](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/No%20More%20findViewById.md)
+- 2016-08-17 [Java 注解（HTML）](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/annotation.html)
 - 2016-08-17 [Jack和Jill的阴暗面](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Jack%E5%92%8CJill%E7%9A%84%E9%98%B4%E6%9A%97%E9%9D%A2.md)
-- 2016-08-17 [Annotation](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/annotation.html)
 - 2016-08-17 [Android项目使用Dagger2进行依赖注入](https://github.com/lihenair/techtranslate/blob/master/archive/earlier/android/Using%20Dagger%202.md)
 
 ### 后端

--- a/archive/earlier/dates.tsv
+++ b/archive/earlier/dates.tsv
@@ -1,31 +1,31 @@
 # domain/filename	date	title
-android/Android 7.1静态快捷方式.md	2016-10-27	Android 7.1 Static Shortcut
-android/Android support Annotation.md	2016-09-28	Android support Annotation
+android/Android 7.1静态快捷方式.md	2016-10-27	Android 7.1 静态快捷方式
+android/Android support Annotation.md	2016-09-28	Android Support 注解
 android/AndroidWeekly248期 源码库与代码.md	2017-08-25	AndroidWeekly248期 源码库与代码
 android/Android原生支持Java8的Lambdas表达式.md	2016-08-25	Android原生支持Java8的Lambdas表达式
 android/Android架构组件 - 查看Lifecycles - 第3部分.md	2017-08-25	Android架构组件 - 查看Lifecycles - 第3部分
 android/Android架构组件 – 查看Room和LiveData – 第一部分.md	2017-08-25	Android架构组件 – 查看Room和LiveData – 第一部分
 android/Android的构建时依赖性修补程序.md	2017-08-25	Android的构建时依赖性修补程序
-android/Andro使用AnimatedVectorDrawables处理线路转换.md	2017-08-25	Andro使用AnimatedVectorDrawables处理线路转换
-android/Animation- Jump-through.md	2017-08-25	Animation: Jump-through
-android/Annotation Processing in Android Studio.md	2016-10-08	Annotation Processing in Android Studio
-android/CompositionLocal-Made-Easy.md	2021-11-07	CompositionLocal-Made-Easy
-android/DI101 - 第一部分.md	2016-12-29	DI101 - 第一部分
-android/DI101-Part1.md	2016-12-29	DI101-第一部分
+android/Andro使用AnimatedVectorDrawables处理线路转换.md	2017-08-25	用 AnimatedVectorDrawable 做路径形变
+android/Animation- Jump-through.md	2017-08-25	动画：Jump-through
+android/Annotation Processing in Android Studio.md	2016-10-08	在 Android Studio 里做注解处理
+android/CompositionLocal-Made-Easy.md	2021-11-07	轻松理解 Jetpack Compose 的 CompositionLocal
+android/DI101 - 第一部分.md	2016-12-29	DI101：Android 平台依赖注入（第一部分）
+android/DI101-Part1.md	2016-12-29	DI101：Android 平台依赖注入（第一部分）
 android/Dagger 2 on producton—reducing methods count.md	2016-08-17	产品使用Dagger 2——减少方法数
 android/DiffUtil是必须的!.md	2017-08-25	DiffUtil是必须的!
-android/Extension Function.md	2017-08-25	Extension Function
+android/Extension Function.md	2017-08-25	Kotlin 扩展函数
 android/Jack和Jill的阴暗面.md	2016-08-17	Jack和Jill的阴暗面
-android/Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!).md	2016-09-07	Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!)
-android/Kotlin Contract.md	2021-03-29	Kotlin Contracts
-android/Kotlin Data Class.md	2017-08-25	Kotlin Data Class
-android/No More findViewById.md	2016-08-17	No More findViewById
+android/Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!).md	2016-09-07	别让运行时权限把应用搞乱（Headless Dialog Fragment）
+android/Kotlin Contract.md	2021-03-29	Kotlin 合约（Contracts）
+android/Kotlin Data Class.md	2017-08-25	Kotlin 数据类
+android/No More findViewById.md	2016-08-17	不再需要 findViewById
 android/Playing with Java annotation processing.md	2016-08-17	把玩Java注解处理
-android/Recomposition-Made-Easy.md	2021-11-07	Recomposition-Made-Easy
+android/Recomposition-Made-Easy.md	2021-11-07	轻松理解 Jetpack Compose 的 Recomposition
 android/RenderScript.md	2017-08-25	RenderScript
 android/Using Dagger 2.md	2016-08-17	Android项目使用Dagger2进行依赖注入
-android/[译]Android架构组件 – 查看ViewModel – 第二部分.md	2017-08-25	[译]Android架构组件 – 查看ViewModel – 第二部分
-android/annotation.html	2016-08-17	Annotation
+android/[译]Android架构组件 – 查看ViewModel – 第二部分.md	2017-08-25	Android架构组件 – 查看ViewModel – 第二部分
+android/annotation.html	2016-08-17	Java 注解（HTML）
 android/何时调整你的网络图片？.md	2017-08-25	何时调整你的网络图片？
 android/使用Dagger 2进行依赖注入.md	2016-08-17	使用Dagger 2进行依赖注入 - API介绍
 android/使用DiffUtil更新RecyclerView的智能方式.md	2017-08-25	使用DiffUtil更新RecyclerView的智能方式

--- a/scripts/translation_archive.py
+++ b/scripts/translation_archive.py
@@ -40,27 +40,32 @@ DOMAIN_HEADINGS = {
 }
 README_TITLES = {
     "10-Claude-Code-Steering-Mechanisms-That-Stop-Agents-From-Ignoring-Instructions.md": "阻止 Agent 忽略指令的 10 种 Claude Code 引导机制",
-    "Android 7.1静态快捷方式.md": "Android 7.1 Static Shortcut",
+    "Android 7.1静态快捷方式.md": "Android 7.1 静态快捷方式",
     "Android Security-Welcome To Shell.md": "Android安全性: 欢迎来到Shell(权限)",
-    "Android support Annotation.md": "Android support Annotation",
+    "Android support Annotation.md": "Android Support 注解",
     "Android原生支持Java8的Lambdas表达式.md": "Android原生支持Java8的Lambdas表达式",
-    "Annotation Processing in Android Studio.md": "Annotation Processing in Android Studio",
-    "CompositionLocal-Made-Easy.md": "CompositionLocal-Made-Easy",
-    "DI101-Part1.md": "DI101-第一部分",
+    "Annotation Processing in Android Studio.md": "在 Android Studio 里做注解处理",
+    "CompositionLocal-Made-Easy.md": "轻松理解 Jetpack Compose 的 CompositionLocal",
+    "DI101-Part1.md": "DI101：Android 平台依赖注入（第一部分）",
     "Dagger 2 on producton—reducing methods count.md": "产品使用Dagger 2——减少方法数",
     "How JPG Works.md": "JPG如何工作的",
     "How WebP Works.md": "WebP是如何工作的(有损模式)",
     "I-Built-a-10-MB-GPU-Accelerated-Terminal-in-Rust-Metal.md": "我用 Rust + Metal 做了个 10 MB 的 GPU 加速终端",
     "Jack和Jill的阴暗面.md": "Jack和Jill的阴暗面",
     "Java注解.md": "Java注解",
-    "Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!).md": "Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!)",
-    "Kotlin Contract.md": "Kotlin Contracts",
-    "No More findViewById.md": "No More findViewById",
-    "NoBuzz.md": "NoBuzz",
+    "Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!).md": "别让运行时权限把应用搞乱（Headless Dialog Fragment）",
+    "Kotlin Contract.md": "Kotlin 合约（Contracts）",
+    "No More findViewById.md": "不再需要 findViewById",
+    "NoBuzz.md": "NoBuzz：把 Claude 的腔调译回人话",
     "Playing with Java annotation processing.md": "把玩Java注解处理",
-    "Recomposition-Made-Easy.md": "Recomposition-Made-Easy",
+    "Recomposition-Made-Easy.md": "轻松理解 Jetpack Compose 的 Recomposition",
     "Using Dagger 2.md": "Android项目使用Dagger2进行依赖注入",
-    "annotation.html": "Annotation",
+    "Andro使用AnimatedVectorDrawables处理线路转换.md": "用 AnimatedVectorDrawable 做路径形变",
+    "[译]Android架构组件 – 查看ViewModel – 第二部分.md": "Android架构组件 – 查看ViewModel – 第二部分",
+    "Animation- Jump-through.md": "动画：Jump-through",
+    "Extension Function.md": "Kotlin 扩展函数",
+    "Kotlin Data Class.md": "Kotlin 数据类",
+    "annotation.html": "Java 注解（HTML）",
     "使用Dagger 2进行依赖注入.md": "使用Dagger 2进行依赖注入 - API介绍",
     "使用Gradle额外属性管理Android依赖版本.md": "使用Gradle额外属性管理Android依赖版本",
     "使用Picasso加载图片.md": "使用Picasso加载图片",
@@ -71,6 +76,7 @@ README_TITLES = {
     "路由器.md": "Router——一切都在正确的位置 映射功能到应用的组件",
     "鼓捣RxAnroid-介绍.md": "鼓捣RxAndroid--介绍",
 }
+SKIP_ARCHIVE_NAMES = {"DI101 - 第一部分.md"}
 LEGACY_DOMAINS = {
     "Android Security-Welcome To Shell.md": "security",
     "How JPG Works.md": "systems",
@@ -84,6 +90,7 @@ LEGACY_DOMAINS = {
     "NoBuzz.md": "ai",
 }
 SKIP_ROOT_NAMES = {"README.md", "AGENTS.md"}
+TRANSLATION_PREFIX_RE = re.compile(r"^(?:【翻译】|\[译\])\s*")
 CATALOG_START = "<!-- catalog:start -->"
 CATALOG_END = "<!-- catalog:end -->"
 
@@ -109,18 +116,22 @@ def github_blob_url(relpath: str) -> str:
     return f"{GITHUB_BLOB}/{encoded}"
 
 
+def _clean_catalog_title(title: str) -> str:
+    return TRANSLATION_PREFIX_RE.sub("", title.strip())
+
+
 def _title_from_text(text: str, filename: str) -> str:
     if filename in README_TITLES:
-        return README_TITLES[filename]
+        return _clean_catalog_title(README_TITLES[filename])
     match = FRONTMATTER_RE.match(text)
     if match:
         title = _parse_simple_yaml(match.group(1)).get("title", "").strip()
         if title:
-            return title
+            return _clean_catalog_title(title)
     heading = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
     if heading:
-        return heading.group(1).strip().rstrip("#").strip()
-    return Path(filename).stem
+        return _clean_catalog_title(heading.group(1).strip().rstrip("#").strip())
+    return _clean_catalog_title(Path(filename).stem)
 
 
 def _load_earlier_meta(earlier_dir: Path) -> dict[str, tuple[str, str]]:
@@ -154,7 +165,7 @@ def scan_archive(repo_root: Path) -> list[CatalogEntry]:
         if len(parts) < 4:
             continue
         date_dir, domain, filename = parts[1], parts[2], parts[-1]
-        if domain not in TECH_DOMAINS:
+        if domain not in TECH_DOMAINS or filename in SKIP_ARCHIVE_NAMES:
             continue
         text = path.read_text(encoding="utf-8", errors="replace")
         title = _title_from_text(text, filename)
@@ -164,7 +175,7 @@ def scan_archive(repo_root: Path) -> list[CatalogEntry]:
             key = f"{domain}/{filename}"
             date, extra_title = earlier_meta.get(key, ("较早", ""))
             if extra_title:
-                title = extra_title
+                title = _clean_catalog_title(extra_title)
         entries.append(CatalogEntry(title=title, relpath=str(rel), date=date, domain=domain))
     return entries
 

--- a/tests/test_translation_archive.py
+++ b/tests/test_translation_archive.py
@@ -80,6 +80,18 @@ class CatalogTest(unittest.TestCase):
             self.assertEqual(by_path["archive/earlier/android/legacy.md"].date, "2016-08-17")
             self.assertEqual(by_path["archive/earlier/android/legacy.md"].title, "旧安卓标题")
 
+    def test_scan_skips_duplicate_names_and_strips_translation_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            android = root / "archive" / "earlier" / "android"
+            android.mkdir(parents=True)
+            (android / "keep.md").write_text("# 【翻译】保留标题\n", encoding="utf-8")
+            (android / "DI101 - 第一部分.md").write_text("# 重复条目\n", encoding="utf-8")
+            entries = ta.scan_archive(root)
+            names = [Path(item.relpath).name for item in entries]
+            self.assertEqual(names, ["keep.md"])
+            self.assertEqual(entries[0].title, "保留标题")
+
 
 class RepoLayoutTest(unittest.TestCase):
     def test_translations_live_under_archive(self) -> None:
@@ -101,6 +113,36 @@ class RepoLayoutTest(unittest.TestCase):
         self.assertIn("### AI", readme)
         self.assertIn("2026-08-23", readme)
         self.assertIn("archive/2026-08-23/ai/", readme)
+
+    def test_readme_explains_inbox_vs_translation_pr_and_lists_ci(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        self.assertIn("| **inbox PR**", readme)
+        self.assertIn("| **译文 PR**", readme)
+        self.assertIn(".github/workflows/article-tools.yml", readme)
+        self.assertIn("close-inbox-pr.yml", readme)
+
+    def test_catalog_uses_chinese_titles_and_skips_duplicate_di101(self) -> None:
+        entries = ta.scan_archive(ROOT)
+        by_name = {Path(item.relpath).name: item.title for item in entries}
+        self.assertEqual(by_name["Android 7.1静态快捷方式.md"], "Android 7.1 静态快捷方式")
+        self.assertEqual(by_name["Recomposition-Made-Easy.md"], "轻松理解 Jetpack Compose 的 Recomposition")
+        self.assertEqual(by_name["CompositionLocal-Made-Easy.md"], "轻松理解 Jetpack Compose 的 CompositionLocal")
+        self.assertEqual(
+            by_name["Keeping Android runtime permissions from cluttering your app (Headless Dialog Fragments!).md"],
+            "别让运行时权限把应用搞乱（Headless Dialog Fragment）",
+        )
+        self.assertEqual(by_name["Andro使用AnimatedVectorDrawables处理线路转换.md"], "用 AnimatedVectorDrawable 做路径形变")
+        self.assertEqual(
+            by_name["[译]Android架构组件 – 查看ViewModel – 第二部分.md"],
+            "Android架构组件 – 查看ViewModel – 第二部分",
+        )
+        self.assertEqual(by_name["NoBuzz.md"], "NoBuzz：把 Claude 的腔调译回人话")
+        names = [Path(item.relpath).name for item in entries]
+        self.assertIn("DI101-Part1.md", names)
+        self.assertNotIn("DI101 - 第一部分.md", names)
+        for title in by_name.values():
+            self.assertFalse(title.startswith("[译]"), title)
+            self.assertFalse(title.startswith("【翻译】"), title)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
刷新仓库首页 README，让用法和译文列表更准确。

- **怎么用：** 用表格写明 inbox PR（`translate/issue-<n>`，不要合入）和译文 PR（`Closes #<issue>`，合入这个）；说明 Issue 关闭后 `close-inbox-pr.yml` 会自动关掉 inbox PR
- **工具：** 补上 `.github/workflows/article-tools.yml`
- **译文目录：** 旧文英文标题改成中文链接文字，去掉 `[译]` 前缀，目录里不再重复列出内容相同的 `DI101 - 第一部分.md`

生成方式仍是 `python3 scripts/rebuild_readme.py`。旧译文正文没有改。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87bb1276-7cb7-4d37-b87d-e315a40ab403?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87bb1276-7cb7-4d37-b87d-e315a40ab403&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

