### PR TITLE
翻译：Go 1.27 发布了

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Issue 关闭后，工作流 `close-inbox-pr.yml` 会自动关掉同号 inbox PR�
 ### 系统
 
 - 2026-08-25 [你的可执行文件其实是个 SQLite 数据库](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-25/systems/Your-executable-is-a-SQLite-database.md)
+- 2026-08-25 [Go 1.27 发布了](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-25/systems/Go-1.27-is-released.md)
 - 2026-08-23 [计算机体系结构原理](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-23/systems/Principles-of-Computer-Architecture.md)
 - 2026-08-23 [如何设计芯片](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-23/systems/How-To-Design-A-Chip-From-Scratch.md)
 - 2026-08-22 [我用 Rust + Metal 做了个 10 MB 的 GPU 加速终端](https://github.com/lihenair/techtranslate/blob/master/archive/2026-08-22/systems/I-Built-a-10-MB-GPU-Accelerated-Terminal-in-Rust-Metal.md)

--- a/archive/2026-08-25/systems/Go-1.27-is-released.md
+++ b/archive/2026-08-25/systems/Go-1.27-is-released.md
@@ -1,0 +1,105 @@
+---
+title: "Go 1.27 发布了"
+title_en: "Go 1.27 is released"
+source_url: https://go.dev/blog/go1.27
+author: Nicholas Husin
+published_at: 2026-08-19
+translated_at: 2026-08-25
+tech_domain: systems
+tags: [go, golang, runtime, generics, toolchain]
+---
+
+# Go 1.27 发布了
+
+原文链接：<https://go.dev/blog/go1.27>
+
+原文作者：Nicholas Husin
+
+作者：Nicholas Husin（代表 Go 团队）
+
+发布于 2026 年 8 月 19 日。
+
+**Go 1.27 现已发布：泛型方法、`encoding/json/v2`、更快的内存分配、goroutine 泄漏剖析，以及更多。**
+
+今天 Go 团队高兴地发布 Go 1.27。二进制归档与安装包见[下载页](https://go.dev/dl/)。
+
+Go 1.27 在语言、工具链、运行时和标准库上带来多项重要增强。下面是一些关键亮点。
+
+## [语言变更](#language-changes)
+
+Go 1.27 对[语言规范](https://go.dev/doc/go1.27#language)引入了三处值得注意的更新。
+
+第一，现已支持泛型方法。例如见 [`math/rand/v2.Rand`](https://go.dev/pkg/math/rand/v2#Rand)：
+
+```
+// Prior to Go 1.27, a separate method on Rand had to be added for each type
+// (unsigned integer methods omitted for brevity).
+func (r *Rand) Int32N(n int32) int32
+func (r *Rand) Int64N(n int64) int64
+func (r *Rand) IntN(n int) int
+
+// Go 1.27 adds a new generic method that works for all integer types.
+func (r *Rand) N[Int intType](n Int) Int
+```
+
+第二，[结构体字面量](https://go.dev/ref/spec#Composite_literals)里的键现在可以是该结构体类型的任意合法[字段选择器](https://go.dev/ref/spec#Selectors)，从而可以直接初始化嵌套或嵌入结构体里的字段：
+
+```
+type Habitat struct {
+    Burrow string
+}
+
+type Gopher struct {
+    Name    string
+    Habitat // Embedded struct.
+}
+
+// Go 1.27 allows using Burrow as a key directly.
+g := Gopher{
+    Name:   "Gopher",
+    Burrow: "Burrow #42",
+}
+```
+
+最后，函数类型推断已推广到所有赋值上下文。泛型函数现在可以在复合字面量、类型转换和 channel 发送里使用，无需显式类型实参：
+
+```
+func GenericFormatter[T any](v T) string {
+    return fmt.Sprintf("value: %v", v)
+}
+
+type IntFormatter func(int) string
+
+// Go 1.27 infers T = int in composite literals, conversions, and channel sends.
+formatters := []IntFormatter{GenericFormatter}
+fn := IntFormatter(GenericFormatter)
+ch := make(chan IntFormatter, 1)
+ch <- GenericFormatter
+```
+
+## [工具改进](#tool-improvements)
+
+* [`go fix`](https://go.dev/doc/go1.27#go-fix) 新增若干 [modernizer](https://go.dev/pkg/golang.org/x/tools/go/analysis/passes/modernize)：`atomictypes`、`embedlit`、`slicesbackward`、`unsafefuncs`。
+* [`go doc`](https://go.dev/doc/go1.27#go-doc) 现支持 `package@version` 查询，例如 `go doc example.com/pkg@v1.2.3`。
+* [`go mod tidy`](https://go.dev/doc/go1.27#go-mod-tidy) 现在会自动把 `go.mod` 里多个 `require` 块合并成标准的 direct / indirect 两块结构。
+
+## [性能与运行时](#performance-and-runtime)
+
+* [按尺寸特化的内存分配](https://go.dev/doc/go1.27#faster-memory-allocation)把小对象（小于 80B）分配成本最多压低约 30%，对分配密集的程序整体性能大约提升 1%。
+* [`runtime/pprof`](https://go.dev/pkg/runtime/pprof) 里的 [`goroutineleak`](https://go.dev/doc/go1.27#goroutineleak-profiles) 剖析现已正式可用，可自动检测永久阻塞的 goroutine。
+
+## [标准库新增](#standard-library-additions)
+
+* [`encoding/json/v2`](https://go.dev/doc/go1.27#jsonv2) 提供可配置选项、默认更严的高阶 JSON 处理；另有 [`encoding/json/jsontext`](https://go.dev/doc/go1.27#jsonv2) 做底层流式处理。现有 [`encoding/json`](https://go.dev/pkg/encoding/json) 包现已由 v2 实现托底，反序列化更快，同时保持向后兼容。
+* [`crypto/mldsa`](https://go.dev/doc/go1.27#crypto_mldsa) 实现后量子 ML-DSA 签名方案（FIPS 204），并接入 [`crypto/x509`](https://go.dev/pkg/crypto/x509) 与 [`crypto/tls`](https://go.dev/pkg/crypto/tls)。
+* [`uuid`](https://go.dev/doc/go1.27#uuid) 原生支持生成与解析 UUID。
+* [`simd`](https://go.dev/doc/go1.27#simd) 与架构相关的 [`simd/archsimd`](https://go.dev/doc/go1.27#archsimd) 提供实验性 SIMD 支持。
+* [`net/http/httptest`](https://go.dev/doc/go1.27#nethttphttptestpkgnethttphttptest) 新增 [`NewTestServer`](https://go.dev/pkg/net/http/httptest#NewTestServer)，提供适合与 [`testing/synctest`](https://go.dev/pkg/testing/synctest) 包一起用的内存假网络。
+
+完整变更与细节请读 [Go 1.27 发布说明](https://go.dev/doc/go1.27)。
+
+接下来几周还会有后续博文，更细地讲 Go 1.27 相关话题。之后可以再回来看。
+
+感谢每一位通过写代码、提 bug、试用实验特性、测试候选版本为本次发布做过贡献的人。一如既往，发现问题请[提交 issue](https://go.dev/issue/new)。
+
+希望你用得开心，Go 1.27！


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
翻译 Go 官方博客《Go 1.27 is released》。

涵盖泛型方法、工具链、运行时分配与 `goroutineleak`、以及 `encoding/json/v2` / ML-DSA / UUID / SIMD 等标准库亮点。原文无可靠专属封面（仅为站点 Gopher 图），故省略头图。领域按语言/运行时/工具链归为 `systems`。

Closes #88

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33c2ce7a-f31b-4dbb-9596-5a0c3420fa1c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33c2ce7a-f31b-4dbb-9596-5a0c3420fa1c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

