### PR TITLE
文档：专有英文不译词表与翻译规则

### DIFF
--- a/.github/agents/article-translator.agent.md
+++ b/.github/agents/article-translator.agent.md
@@ -18,6 +18,7 @@ When assigned an issue or pull request:
 4. Run `python scripts/capture_media.py --inbox _inbox --repo-root .` when media comments exist.
 5. Write one Chinese markdown file per article under `archive/<translated_at>/<tech_domain>/` (YAML meta + body header, no `【翻译】` on GitHub). Use inbox `title_zh` as `title` when present. Update the README catalog (`python3 scripts/rebuild_readme.py`), keep `assets/<slug>/` GIFs, and delete the inbox source. The translation PR body must include `Closes #<issue>`. **Never merge** the Action inbox PR (`translate/issue-<n>`, title `Translate: …`). Close it without merging as soon as the translation PR exists; when the user asks to merge the translation, merge that PR **and** close any still-open related inbox PR for the same issue.
 6. **Voice checklist before opening/updating the PR** (skill § Voice and polish): pick the row for this article type; rewrite any paragraph that still reads like DeepL / stacked「的」/ stiff「当…的时候」; founder essays need rhythm and cold humor, not press-release Chinese; tech posts need engineer cadence, not textbook tone.
-7. Do not change unrelated translations.
+7. **Keep-English checklist**: follow `docs/keep-english-terms.md`. Do not translate product / architecture / API / engine proper names into Chinese. If you meet a new proper name, add it to that glossary in the same PR.
+8. Do not change unrelated translations.
 
 If a URL cannot be fetched and there is no inbox file, comment on the issue with the error and stop. Do not guess the article body.

--- a/.github/skills/translating-articles/SKILL.md
+++ b/.github/skills/translating-articles/SKILL.md
@@ -107,7 +107,7 @@ Body header, in this order, blank line between blocks:
 
 发布于 2026 年 1 月 2 日。
 
-**加粗导语。术语第一次写成 中文（English）。**
+**加粗导语。通用概念才用 中文（English）；专名直接英文。**
 ```
 
 Omit any header line you cannot fill. Do not use `[原文链接](URL)`.
@@ -123,15 +123,19 @@ Omit any header line you cannot fill. Do not use `[原文链接](URL)`.
 | 工程技术文 | `ai` / `backend` / `frontend` / `devops` / `systems` / `graphics` / `security` / `android` / `mobile` | 该领域资深工程师：清楚、利落、术语准；可以说「坑」「摊开」「顶满」，少文言腔 |
 | 创业 / 创始人随笔 | `other` + startup / YC / founder 故事 | 叙事散文：有节奏、有画面；保留冷幽默与自嘲，别写成通稿 |
 | 产品 / 增长 / 运营 | 常落在 `other` 或夹带业务词 | 产品/运营人说话：结论先行，例子落地，少堆术语括号 |
-| 安全研究 | `security` | 安全研究员：精确、克制；漏洞名与概念第一次给中英对照 |
+| 安全研究 | `security` | 安全研究员：精确、克制；**漏洞代号 / CVE 留英文**；仅通用概念做中英对照 |
 
 ### 润色规则
 
 - **意译优先**：长定语、英文从句拆成短句；「It is difficult to… when…」写成中文自然因果，不要「当…的时候，很难…」一路套。
 - **忌翻译腔**：少用「进行」「进行了」「进行中」；少「一个…的…的…」叠罗汉；少「使得」「予以」「针对…进行」。
-- **术语**：技术文第一次 `中文（English）`，后文跟邻近习惯；叙事文里机构名可保留英文缩写并在首次括注全称（如 YC、ETH）。
+- **术语 / 专名（必读 `docs/keep-english-terms.md`）**：
+  - **专有英文不译**：产品名、架构名（如 Bridgeless）、API / 类 / 方法名、引擎名、协议名、标准特性正式名、常见指标缩写 → 正文直接写英文，禁止「无桥接（Bridgeless）」「应用编程接口（API）」这类硬译。
+  - **通用概念**才首次 `中文（English）`（如 `竞态（race condition）`）；后文跟邻近习惯。
+  - 表里没有的新专名：正文留英文，并**补进** `docs/keep-english-terms.md`。
+  - 叙事文机构缩写可保留英文（YC、ETH）；需要时首次括注英文全称，不要译成中文专名。
 - **语气对齐原文**：原文毒舌就毒舌，原文冷静就冷静；不要统一成公文或鸡汤。
-- **自检**：读一遍，若明显像 DeepL / 字面直译，整段重写后再提交。
+- **自检**：读一遍，若明显像 DeepL / 字面直译，整段重写后再提交；再扫一遍是否把专名译成了中文。
 
 反例（生硬）→ 正例（可接受）：
 
@@ -143,7 +147,7 @@ Omit any header line you cannot fill. Do not use `[原文链接](URL)`.
 - Simplified Chinese, **polished to the voice table above**. Keep code, commands, API names, and original raster image URLs (`png` / `jpg` / `webp`). Same-origin diagram iframes and SVG (inline or `.svg`) must be converted into `assets/<slug>/` GIF or PNG; GitHub cannot show those iframes, and Jina drops them. From `archive/<date>/<domain>/` use `../../../../assets/<slug>/visual-….gif`.
 - Copy **every** inbox raster diagram into the Chinese post at the matching section — not only `cover_image`. Skip any body image that is the same asset as `文章头图` (do not paste the cover twice). X/Twitter long posts often have 3–6 `pbs.twimg.com/media/…` diagrams that Jina keeps and x.com HTML drops. **X Articles** (`x.com/i/article/…` linked from a status) are worse: Jina may 403 and HTML often only has the cover — `article_tools` must use `api.fxtwitter.com` so inbox keeps body `MEDIA` blocks and embedded tweets. If the Chinese file only has the header cover, the body diagrams are missing.
 - Headings: `## [引言](#introduction)` — Chinese title, original slug.
-- First use of a term: `消毒（sanitization）`.
+- First use of a **general concept**: `消毒（sanitization）`. Proper names stay English per `docs/keep-english-terms.md` (e.g. `Bridgeless`, `JSI`, `Class Prefix Selector`).
 - No `iframe`. No `p9-xtjj-sign` / `link.juejin.cn` URLs.
 - Videos always keep the text link:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This repository publishes Simplified Chinese translations of English software articles.
 
-When the user (or a GitHub issue) provides an article URL, follow `.github/skills/translating-articles/SKILL.md`. Prefer `_inbox/*.source.md` if the GitHub Action already fetched the page. Output must match `docs/superpowers/specs/2026-08-22-translation-format-design.md`.
+When the user (or a GitHub issue) provides an article URL, follow `.github/skills/translating-articles/SKILL.md`. Prefer `_inbox/*.source.md` if the GitHub Action already fetched the page. Output must match `docs/superpowers/specs/2026-08-22-translation-format-design.md`. Keep product / architecture / API proper names in English per `docs/keep-english-terms.md` (add new terms to that table when missing).
 
 Use the Copilot custom agent `.github/agents/article-translator.agent.md` when working from GitHub.com.
 

--- a/docs/keep-english-terms.md
+++ b/docs/keep-english-terms.md
@@ -1,0 +1,138 @@
+# 专有英文不译表（keep-English）
+
+翻译时：**产品名、架构名、API / 类型 / 符号、引擎名、协议名、标准里的正式特性名**直接写英文，不要硬译成中文，也不要写成 `中文（English）` 堆砌。
+
+仅当是**通用概念**且中文圈有稳定译法时，才首次用 `中文（English）`（如 `竞态（race condition）`、`消毒（sanitization）`）。后文可只用中文或英文，跟邻近习惯。
+
+遇到表里没有、但明显是专名的词：**正文保留英文**，并补进本表对应分类（PR 里一起改）。
+
+权威引用：`.github/skills/translating-articles/SKILL.md` § Voice → 术语；`docs/superpowers/specs/2026-08-22-translation-format-design.md`。
+
+---
+
+## 怎么判断（口诀）
+
+| 留英文 | 可译 / 中英一次 |
+| --- | --- |
+| 专有名词、商标、产品、仓库名 | 通用工程概念（竞态、死锁、消毒、幂等） |
+| 架构 / 模式正式名（Bridgeless、New Architecture） | 叙述性短语（「热重载」「冷启动」可中文） |
+| API、类、方法、字段、CLI、配置键 | 读者需要中文才能懂的安全/理论概念 |
+| 引擎 / 运行时专名（Hermes、JSI、V8） | — |
+| 标准特性正式英文名（Class Prefix Selector） | 中文标题可意译；正文专名用英文 |
+| 指标缩写（TTI、TTR、FPS、TTFB） | 首次可 `TTI（Time to Interactive）`，不要「可交互时间（TTI）」硬把专名译掉 |
+| 公司 / 会议 / RFC / Issue 里的代号 | — |
+
+反例 → 正例：
+
+- 「无桥接模式（Bridgeless）」→ `Bridgeless`
+- 「应用编程接口（API）」→ `API`
+- 「类名前缀选择器（Class Prefix Selector）」→ 正文 `Class Prefix Selector`（`.prefix-*`）；标题可写「CSS 类名前缀选择器」这类读者向标题
+- 「共享值（shared value）」→ Reanimated 语境写 `shared value`（或 `useSharedValue`）
+- 「正式可用（generally available）」→ `GA` / `generally available`
+
+---
+
+## React Native / 移动
+
+| 保留英文 | 备注 |
+| --- | --- |
+| React Native | |
+| Bridgeless | 勿译「无桥接」 |
+| Bridge / Old Bridge | 可写 Old Bridge；勿强行「旧桥」当专名 |
+| New Architecture | |
+| TurboModule / Turbo Modules | |
+| Fabric | |
+| JSI | JavaScript Interface |
+| Hermes | |
+| Metro | |
+| CodePush | |
+| OTA | 可保留 OTA；勿写「OTA（空中下载）」除非读者向科普 |
+| Expo | |
+| Expo Router | |
+| Observe | Expo 产品名 |
+| React Navigation | |
+| Reanimated / react-native-reanimated | |
+| Gesture Handler | |
+| CallInvoker / RuntimeExecutor | |
+| RCTInstance / RCTBridge | |
+| install / invalidate | 作 API 名时保持英文（可带 \`\`） |
+| op-sqlite / opsqlite | |
+| Nitro Modules / NitroFetch | |
+| VisionCamera | |
+| FlashList | |
+
+## Web / CSS / 前端
+
+| 保留英文 | 备注 |
+| --- | --- |
+| CSS / Selectors Level 5 | |
+| Class Prefix Selector | 正文专名；`.prefix-*` / `.btn-*` |
+| `@supports` / `@media` / `@keyframes` | |
+| Blink / Gecko / WebKit | 引擎名；可写 Chromium（Blink）这种产品（引擎） |
+| Chromium / Firefox / Safari | |
+| CodePen | |
+| React / Vue / Svelte / Solid | |
+| Next.js / Nuxt / Vite | |
+| Server Components / RSC | |
+| Tailwind CSS | |
+| WebAssembly / Wasm | |
+| DOM / HTML / SVG / SMIL | |
+| Shadow DOM / Custom Elements | |
+| Playwright / Puppeteer | |
+| Testing Library / Jest / Vitest | |
+
+## AI / 智能体
+
+| 保留英文 | 备注 |
+| --- | --- |
+| LLM / GPT / Claude / Gemini | |
+| OpenAI / Anthropic | |
+| MCP | Model Context Protocol；勿译「模型上下文协议」当专名替代 |
+| Agent / tool calling | tool calling 保留；「工具调用」可作叙述 |
+| RAG / embedding | |
+| Cursor / Copilot | |
+| LSP / grep | 作工具名时保留 |
+| token / tokenizer | 常留 token |
+
+## 后端 / 系统 / 安全
+
+| 保留英文 | 备注 |
+| --- | --- |
+| API / SDK / CLI / RPC / gRPC | |
+| HTTP / HTTPS / WebSocket / TCP / UDP | |
+| SQL / SQLite / PostgreSQL / Redis | |
+| Kubernetes / K8s / Docker | |
+| CI / CD / GitHub Actions | |
+| XSS / CSRF / SSRF / RCE | 漏洞名保留英文 |
+| OAuth / OIDC / JWT | |
+| WASM / eBPF | |
+
+## 指标与缩写
+
+| 保留英文 | 备注 |
+| --- | --- |
+| TTI / TTR / TTFB / FCP / LCP / CLS / INP | 首次可英文全称括注 |
+| FPS / CPU / GPU / RAM | |
+| GA / RC / beta | generally available → GA 或原文英文 |
+
+## 通用概念（仍可用中文（English）一次）
+
+这些**不是**「专名不译」；需要时首次对照：
+
+| 中文 | English |
+| --- | --- |
+| 竞态 | race condition |
+| 死锁 | deadlock |
+| 消毒 / 净化 | sanitization |
+| 幂等 | idempotent |
+| 背压 | backpressure |
+| 热重载 | hot reload（叙述可用中文；产品 Hot Reload 可留英文） |
+| 冷启动 / 热启动 | cold start / warm start |
+
+---
+
+## 维护
+
+1. 翻译前快速扫本表相关分类。  
+2. 新专名第一次进仓库：加行到本表，避免下次又被译掉。  
+3. 不要把本表当成「必须首次括注英文」的清单——表内词默认**只写英文**。

--- a/docs/superpowers/specs/2026-08-22-translation-format-design.md
+++ b/docs/superpowers/specs/2026-08-22-translation-format-design.md
@@ -75,7 +75,7 @@ Frontmatter 之后按这个顺序，中间空一行：
 
 发布于 2026 年 8 月 6 日星期四 22:00 UTC。更新于 2026 年 8 月 13 日星期四 09:21 UTC。
 
-**加粗导语。关键术语第一次出现写成 中文（English）。**
+**加粗导语。通用概念第一次可写 中文（English）；产品名 / 架构名 / API 等专有英文不译（见 `docs/keep-english-terms.md`）。**
 ```
 
 | 行 | 规则 |
@@ -93,7 +93,8 @@ Frontmatter 之后按这个顺序，中间空一行：
 - 简体中文，且必须**按文类润色**：工程文用该领域工程师口吻；创业/随笔用叙事散文口吻；安全研究用研究员口吻。意译优先，拆长句，少用翻译腔（少「进行了 / 针对…进行」、少「使得」「予以」、少「一个…的…的…」叠罗汉）。成稿应像中文作者写的，不是字对字直译。
 - 代码块、命令、类名、API、原文图片 URL 不译。
 - 章节标题译成中文，锚点保留原文 slug：`## [引言](#introduction)`。原文没有 slug 时，用标题英文 kebab-case。
-- 术语第一次：`消毒（sanitization）`；后文可只用中文或英文，跟邻近译文习惯。叙事文里机构名可保留缩写并首次括注。
+- **专有英文不译**（产品、架构、API、引擎、协议、标准特性正式名、指标缩写）：直接写 `Bridgeless` / `JSI` / `TTI`，不要「无桥接（Bridgeless）」；词表见 `docs/keep-english-terms.md`，缺词就补表。
+- 通用概念第一次：`消毒（sanitization）`；后文可只用中文或英文。叙事文机构缩写可保留并首次括注英文全称。
 - 图片：栅格图（png / jpg / webp）尽量用原文 URL；alt 写成中文说明。inbox / Jina 正文里的示意图都要进译文对应段落，但不能把已作 `文章头图` 的封面再贴一遍。X 长文的示意图常在 `pbs.twimg.com/media/`，直抓 x.com HTML 往往只剩头图；**X Article** 正文图在 fxtwitter 的 `content.blocks` / `media_entities` 里，抓取脚本应走 `api.fxtwitter.com`。不要把掘金 `p9-xtjj-sign` 签名链写进仓库。
 - 同站图示 iframe、内联 SVG、`.svg` 插图：Jina 经常丢掉，HTML 解析要标成 `media:page-visual` / `media:svg` / `section-anim`，转成 `assets/<slug>/` 下的 GIF（有动画）或 PNG（静帧）。译文里不要写 iframe。从 `archive/<date>/<domain>/` 引用时用 `../../../../assets/<slug>/visual-….gif`。
 - 不要把范文里的掘金跳转链 `link.juejin.cn` 学过来。
@@ -165,7 +166,7 @@ GitHub Markdown **不能**内嵌 YouTube / iframe。仓库里不写 iframe，也
 | section 内多张按序帧图 | 按 8fps 估算：帧数 ≤ 120 则拼 GIF，否则只留第一张静图 + 说明 |
 | 纯 CSS / HTML `@keyframes`，无媒体文件 | 无片源：最多录 15 秒转 GIF；Playwright 不可用时先用系统 Chrome/Chromium headless 或 cairosvg 对 `_inbox/media/*.html` / SVG 出静帧（优先）或拼帧 GIF；仍失败才允许「原文为网页动画」，且**不能**用该句顶替已有可用 PNG/GIF |
 | 同站图示 iframe（SVG / JS 动画，非 YouTube / Twitter） | 当网页动画录：默认 4 秒，JS 打开；各帧相同则落 PNG |
-| `<img src="*.svg">` 或够大的正文内联 SVG（不是 48px 以下图标） | 静图转 PNG，带 `<animate>` / CSS 动画的转 GIF；脚本 `skipped-no-browser` 时同样要走 Chrome/cairosvg 补救，不要直接写占位句 |
+| `<img src="*.svg">` 或够大的正文内联 SVG（不是 48px 以下图标） | 静图转 PNG；带 `<animate>` / CSS 动画的用 `svg.setCurrentTime(t)` 逐帧截屏拼 GIF（约 6–8fps、一个循环）。脚本 `skipped-no-browser` 时同样要走 Chrome CDP / headless 补救，不要用静帧 PNG 或「原文为网页动画」顶替动效 |
 
 不要把整页滚动、导航、广告当成动画。只处理文章正文里、看起来像插图的那一块：`demo` / `anim` / `gif` 一类 class，或节点上真有 `animation:` / `@keyframes`。正文里出现 “animation” 这个词、外层包着几张说明图的 `<section>`，都不算。同站 stylesheet 会内联进 `section` 片段，相对 `url()` 改成绝对地址后再录。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更

建立「专有英文不译」规则与活词表，避免再把 Bridgeless / JSI / API / Class Prefix Selector 等硬译成中文。

- 新增 [`docs/keep-english-terms.md`](../blob/cursor/keep-english-terms-glossary-c989/docs/keep-english-terms.md)：分类词表 + 判断口诀；缺词就补表
- Skill / 格式规格 / article-translator agent：通用概念才用 `中文（English）`；专名直接英文

以后翻译前扫词表；遇到新专名在同 PR 补进表里。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e55ed2bc-1d60-4d28-82fa-d90e947ac989?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e55ed2bc-1d60-4d28-82fa-d90e947ac989&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

