### PR TITLE
翻译：RN 导航现状、Expo Modules 2.0、Half Past Fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ Issue 关闭后，工作流 `close-inbox-pr.yml` 会自动关掉同号 inbox PR�
 
 ### 移动
 
+- 2026-09-12 [React Native 导航现状](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/mobile/React-Native-Navigation-Benchmarks.md)
 - 2026-09-12 [React Native 0.88.0-rc.0](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/mobile/React-Native-0.88.0-rc.0.md)
+- 2026-09-12 [Expo Modules 2.0 抢先看](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/mobile/An-early-look-at-Expo-Modules-2.0.md)
 - 2026-09-11 [原生成了 Shopify 移动端的未来（2026）](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-11/mobile/Native-is-now-the-future-of-mobile-at-Shopify-2026.md)
 - 2026-09-05 [使用 React Native Super App Showcase 仓库](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-05/mobile/Working-With-the-React-Native-Super-App-Showcase-Repository.md)
 - 2026-09-05 [介绍 Expo Observe：应用可观测性](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-05/mobile/Introducing-Observe-Performance-monitoring-for-Expo-apps-now-generally-available.md)
@@ -173,6 +175,7 @@ Issue 关闭后，工作流 `close-inbox-pr.yml` 会自动关掉同号 inbox PR�
 - 2026-09-12 [React 现在全线锈化了](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/frontend/React-Now-Rusted-All-The-Way-Out.md)
 - 2026-09-12 [React DevTools CDT MCP](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/frontend/react-devtools-cdt-mcp.md)
 - 2026-09-12 [React Compiler 的 lint：Oxlint 迎来 Rust 原生加速](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/frontend/React-Compiler-Linting-Just-Got-a-Rust-Native-Speedup-in-Oxlint.md)
+- 2026-09-12 [Fetch 只等到一半](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-12/frontend/Half-Past-Fetch.md)
 - 2026-09-10 [React 19.3](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-10/frontend/React-19.3.md)
 - 2026-09-05 [CSS 的未来：用类名前缀选择器一次命中多个 class](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-05/frontend/The-Future-of-CSS-Target-Multiple-Classes-with-the-Class-Prefix-Selector.md)
 - 2026-09-03 [让 React Testing Library 测试快 43%](https://github.com/lihenair/techtranslate/blob/master/archive/2026-09-03/frontend/Making-React-Testing-Library-Tests-43-Faster.md)

--- a/archive/2026-09-12/frontend/Half-Past-Fetch.md
+++ b/archive/2026-09-12/frontend/Half-Past-Fetch.md
@@ -1,0 +1,478 @@
+---
+title: "Fetch 只等到一半"
+title_en: "Half Past Fetch"
+source_url: https://blog.gaborkoos.com/posts/2026-09-08-Half-Past-Fetch/
+author: Gabor Koos
+published_at: 2026-09-08
+translated_at: 2026-09-12
+tech_domain: frontend
+tags: [frontend, fetch, javascript, node, http]
+cover_image: https://opengraph.b-cdn.net/production/images/74740c4e-d40d-49be-83fb-7170084dbda1.png?token=3Pxj4Ccc7Z93zXgN6-HhJM8U3lpcnqtTs8xNIPoUzF4&height=614&width=620&expires=33290472379
+---
+
+# Fetch 只等到一半
+
+原文链接：<https://blog.gaborkoos.com/posts/2026-09-08-Half-Past-Fetch/>
+
+原文作者：Gabor Koos
+
+![文章头图](https://opengraph.b-cdn.net/production/images/74740c4e-d40d-49be-83fb-7170084dbda1.png?token=3Pxj4Ccc7Z93zXgN6-HhJM8U3lpcnqtTs8xNIPoUzF4&height=614&width=620&expires=33290472379)
+
+作者：[Gabor Koos](https://blog.gaborkoos.com)
+
+发布于 2026 年 9 月 8 日。
+
+**`await fetch(url)` 只等到响应头；body 仍在路上。超时、abort、clone 和行为差异，都要从这个缝隙理解。**
+
+_收录于 [Javascript Weekly - 2026-09-08](https://javascriptweekly.com/issues/801) 与 [Node Weekly - 2026-09-10](https://nodeweekly.com/issues/640)_
+
+`await fetch(url)` 看起来像在等完整响应，其实只等 headers。Promise settle 时你手里已经是一个 `Response`，body 还在一条仍然打开的连接上往下走，而 `await` 之后的代码会在字节仍在线上时开始跑。所以你通常要 await 两次：
+
+```js
+const response = await fetch(url) // awaits the headers
+const body = await response.json() // awaits the body
+```
+
+这道缝很容易被忽略，因为它通常极小。服务器若把 headers 与 body 一起送出，从 fetch promise resolve 到最后一字节落地往往只有几分之一毫秒，你写的任何东西都不会察觉。若在 headers 与 body 之间插入 300ms 停顿，promise 仍大约在 1ms 后 settle，body 再晚 300ms 结束。resolve 时间不会移动，因为它等的那件事发生在老位置。
+
+下文会过一遍：规范说 promise 在等什么；你在决定是否读 body 时连接会怎样；还没有可复制的成品时 `clone()` 做什么；已经拿到 `Response` 之后 abort 怎样表现；以及你以为罩住整次请求的超时为什么经常罩不住。浏览器与 Node 之间也有值得知道的细微差别。
+
+## [Promise 很早就 settle](#the-promise-settles-early)
+
+[HTTP-network fetch](https://fetch.spec.whatwg.org/#http-network-fetch) 是跟 socket 说话的那套算法。服务器可能在真正响应前先发临时的 1xx，所以它循环读入 status line，丢掉 1xx 区间的一切。最终 status 出现后，它等到最后一个 header 字节，离开循环，给响应挂上一条新的 `ReadableStream`，并把该响应交回调用方。紧挨着这最后一步下面印着一条注记：_Typically response's body's stream is still being enqueued to after returning_。同一警告在更高一层的 [HTTP fetch](https://fetch.spec.whatwg.org/#http-fetch) 里又出现一次。
+
+你正在 await 的那个 promise，由规范里叫 `processResponse` 的算法 resolve：它在同一时刻拿到 response，并被排进 task 队列。那条路径完全不看 body；你拿回的 `Response` 的 headers、status、URL 都已最终确定，而 `body` 是一条网络层仍在往里写的 stream，字节到达时先填进缓冲区。读 body 是你还没开始的另一次操作。
+
+在浏览器控制台或 Node REPL 里跑下面片段，就能看见这道缝：
+
+```js
+const t0 = performance.now()
+const response = await fetch('https://httpbin.org/drip?duration=3&numbytes=120&delay=0')
+console.log('headers  ', (performance.now() - t0).toFixed(1), 'ms', response.status)
+await response.arrayBuffer()
+console.log('body done', (performance.now() - t0).toFixed(1), 'ms')
+```
+
+```
+headers   250.7 ms 200
+body done 3445.8 ms
+```
+
+约 250ms 时 status 与 headers 已可读，body 最后一字节约在 3445ms 到达。普通端点若 headers 与 body 一起发送，两个数字只差几分之一毫秒，所以只有服务器或网络变慢时，这道缝才能量得出来。
+
+`HEAD` 请求与 [null body statuses](https://fetch.spec.whatwg.org/#null-body-status)（101、103、204、205、304）是例外。[Main fetch](https://fetch.spec.whatwg.org/#main-fetch) 会把它们的 body 设为 null，并忽略任何向它 enqueue 的动作，于是 `response.body` 是 `null` 而不是空 stream，也没有东西仍在路上。本文其余部分谈的是别的那些响应。
+
+## [Socket 仍是你的](#the-socket-is-still-yours)
+
+看一眼 status 就走开是常见写法：你发出请求，promise resolve，status 是 500 或 404 或干脆不是你想要的，于是提前 return，碰也不碰 `response.body`。在 HTTP/1.1 下，一条连接一次只承载一次交换，只有当前响应读到最后一字节，才能交还连接池。未读的 body 会在线上留下永远没人接收的字节，客户端也无法找到下一次响应的起点，于是连接被关闭而不是复用。
+
+这有没有代价，取决于 body 有多大。对本地服务器连续发十次请求，先每次读 body、再每次忽略，就能看见 Node 里的分界：
+
+```js
+import { createServer } from 'node:http'
+
+let seen = new Set()
+const server = createServer((req, res) => {
+  seen.add(req.socket)
+  const size = Number(new URL(req.url, 'http://x').searchParams.get('size'))
+  res.writeHead(200, { 'content-type': 'application/octet-stream' })
+  res.end(Buffer.alloc(size))
+})
+await new Promise((r) => server.listen(0, r))
+const port = server.address().port
+
+for (const kb of [4, 8, 16, 32, 64]) {
+  const counts = []
+  for (const read of [true, false]) {
+    seen = new Set()
+    for (let i = 0; i < 10; i++) {
+      const response = await fetch(`http://localhost:${port}/?size=${kb * 1024}`)
+      if (read) await response.arrayBuffer()
+    }
+    counts.push(seen.size)
+  }
+  console.log(`${kb}KB  read: ${counts[0]}  ignored: ${counts[1]}`)
+}
+server.close()
+process.exit(0)
+```
+
+```
+4KB   read: 2  ignored: 2
+8KB   read: 2  ignored: 2
+16KB  read: 2  ignored: 10
+32KB  read: 2  ignored: 10
+64KB  read: 2  ignored: 10
+```
+
+低于 16KB 时完全没差别。promise resolve 时整份响应已经到达并缓冲完毕，从传输层看，无论你的代码看没看这些字节，交换都已完成。从 16KB 起，每次忽略响应都会烧掉一条连接，10 次请求需要 10 条而不是 2 条。
+
+这个数字是 runtime 的属性，不是 fetch 的。Chrome 能容忍大得多的未读 body，单连接复用可到 512KB，大约在 512KB 到 4MB 之间才开始多开连接。与 Node 的分界相差两个数量级，意味着浏览器里能蒙混过关的写法，到了服务端未必行。两个数字都来自底下缓冲区大小，谁都不能当硬保证；稳妥读法是：你永远不碰的 body，可不可能消耗连接，取决于代码跑在哪。
+
+显式取消 stream 也赎不回连接。把循环里的忽略换成 `await response.body.cancel()`，计数不变：4KB、8KB 仍是 2 条，16KB 及以上仍是 10 条，跟什么都不说就走开一样。取消只是告诉 stream 你不打算读了，连接对此无能为力，因为服务器已承诺发送的字节照样未交付。把 body 读完，才是把连接还回池子的唯一办法。
+
+由此产生的失败是渐进的。十二个并发的未读 4MB 响应不会卡死源站：服务器在十二条 socket 上收到全部十二个，同时发出的无关请求仍能在两毫秒内拿回 headers。你得到的是连接膨胀——比工作所需更多的 socket、服务端更多的文件描述符、以及负载下扩张、压力退去又收缩的客户端连接池。没有什么立刻炸裂，所以能在生产里跑很久，直到有人问为什么连接数看起来不对劲。
+
+大 body 与小 body 行为不同的原因是[背压（backpressure）](https://blog.gaborkoos.com/posts/2026-01-06-Backpressure-in-JavaScript-the-Hidden-Force-Behind-Streams-Fetch-and-Async-Code/)。网络层随字节到达填充内部缓冲，一旦超过实现选定的上限就停止从 socket 拉取，等 reader 来排空。小响应永远到不了上限，在你做任何决定前就被完全吸收。大响应会在传输中途停下，等待一个在这种模式下永远不会出现的消费者。
+
+## [Clone 什么也没拷贝](#clone-copies-nothing)
+
+响应 body 只能读一次。`clone()` 是逃生口，通常在两段代码都想要同一份 payload 时用到：缓存要存一份拷贝、调用方拿原件，或去重层把同一进行中请求分给多个等待者。名字暗示会做拷贝，于是容易假定：调用当下就复制了某块内存，然后两个对象分道扬镳。
+
+那一刻没什么可拷。规范用一行定义 [cloning a body](https://fetch.spec.whatwg.org/#concept-body-clone)：_Let « out1, out2 » be the result of teeing body's stream_。Tee 一条 stream 是在同一源上产生两个 reader，而这里的源是仍在投递的 socket。`clone()` 真正创建的是一条仍在流动的管道上的分叉。
+
+后果是两个分支绑在一起。Tee 必须把相同字节交给两边，所以先读的那一侧拉到的 chunk 必须留着，直到另一侧也要。若一侧永远不要，chunk 就会堆积。服务 60MB 并在读取时采样常驻内存，能看见代价：
+
+```js
+import { createServer } from 'node:http'
+
+const MB = 1024 * 1024
+const server = createServer((req, res) => {
+  res.writeHead(200, { 'content-type': 'application/octet-stream' })
+  const chunk = Buffer.alloc(MB)
+  let sent = 0
+  const write = () => {
+    while (sent < 60 * MB) {
+      sent += MB
+      if (!res.write(chunk)) return res.once('drain', write)
+    }
+    res.end()
+  }
+  write()
+})
+await new Promise((r) => server.listen(0, r))
+const url = `http://localhost:${server.address().port}/`
+
+const mode = process.argv[2]
+let max = 0
+const sampler = setInterval(() => {
+  max = Math.max(max, process.memoryUsage().rss)
+}, 5)
+
+const response = await fetch(url)
+const copy = mode === 'plain' ? null : response.clone()
+await response.arrayBuffer()
+
+clearInterval(sampler)
+console.log(mode, (max / MB).toFixed(1), 'MB')
+server.close()
+process.exit(0)
+```
+
+每种 mode 必须在自己的进程里跑，否则第二次测量会继承第一次已经长大的 heap，数字就没意义了：
+
+```
+plain    116.1 MB
+clone    169.3 MB
+```
+
+被遗弃的分支大约再花 55MB，接近响应大小，因为 tee 在为永远不来的 reader 持有每块 chunk 的第二份引用。
+
+缓冲的数据是真正留住的，不是重新拉的。先把第一分支读完，等半秒让交换彻底结束，再读被遗弃的分支，仍能得到完整 60MB，而且远快于网络第一次投递：
+
+```js
+import { createServer } from 'node:http'
+
+const server = createServer((_, res) => {
+  res.writeHead(200, { 'content-type': 'application/octet-stream' })
+  res.end(Buffer.alloc(60 * 1024 * 1024))
+})
+await new Promise((r) => server.listen(0, r))
+const url = `http://localhost:${server.address().port}/`
+
+const response = await fetch(url)
+const copy = response.clone()
+const first = await response.arrayBuffer()
+console.log('first branch', first.byteLength)
+
+await new Promise((r) => setTimeout(r, 500))
+const t0 = performance.now()
+const second = await copy.arrayBuffer()
+console.log('second branch', second.byteLength, 'in', (performance.now() - t0).toFixed(1), 'ms')
+
+server.close()
+process.exit(0)
+```
+
+```
+first branch 62914560
+second branch 62914560 in 32.5 ms
+```
+
+后面的例子复用同一段七行服务器，因此只改 `const url` 之后的部分。
+
+只要未读分支仍可达，这些内存就会一直占着。在缓存里 clone 响应并异步写入拷贝时，clone 会活到写完为止，整份 payload 其间都坐在内存里。[Durable Objects cache](https://blog.gaborkoos.com/posts/2026-03-29-One-Cache-to-Rule-Them-All-Handling-Responses-and-In-Flight-Requests-with-Durable-Objects/) 正因这个原因在三个不同点调用 `.clone()`，共享响应的每个消费者一次，而每一次调用都是必须有人排空的分叉。
+
+排序规则来自同一机制。只有一条 stream 可分叉，所以分叉必须发生在有人开始从它拉取之前：
+
+```js
+const response = await fetch(url)
+await response.arrayBuffer()
+response.clone()
+// TypeError: Response.clone: Body has already been consumed.
+```
+
+单次 `read()` 也会触发同样错误，因为从源取走一个 chunk 就足以让两个分支不再相等。`response.bodyUsed` 报告状态，且按对象计而不是共享：原件读完后它在原件上是 `true`，在拷贝上是 `false`。Body 消费规则，以及 TypeScript 表达不了这些事，见 [Decorating Promises Without Breaking Them](https://blog.gaborkoos.com/posts/2026-04-10-Decorating-Promises-Without-Breaking-Them/)。
+
+取消你决定不读的 clone，会释放留住的 chunk。在上面的测量里加上 `copy.body.cancel()`，结果到 109.7MB，略低于 plain read，但有个陷阱：
+
+```js
+const response = await fetch(url)
+const copy = response.clone()
+await copy.body.cancel()
+await response.arrayBuffer()
+```
+
+这会死锁。取消 tee 的一侧会返回一个 promise，直到另一侧结束才 settle；而另一侧在下一行，永远走不到。不 await 地启动 cancel，再观察它何时 settle，能看见依赖：
+
+```js
+const response = await fetch(url)
+const copy = response.clone()
+
+const t0 = performance.now()
+let settled = false
+copy.body.cancel().then(() => {
+  settled = true
+  console.log('cancel settled at', (performance.now() - t0).toFixed(1))
+})
+
+await new Promise((r) => setTimeout(r, 200))
+console.log('after 200ms, settled?', settled)
+
+await response.arrayBuffer()
+console.log('original read at', (performance.now() - t0).toFixed(1))
+```
+
+```
+after 200ms, settled? false
+cancel settled at 464.6
+original read at 465.4
+```
+
+两百毫秒后 cancel 仍 pending，只有另一侧读到响应末尾时才 settle，所以先 await 它永远等不回来。
+
+当两侧以大致相同的速率读取时，缓冲保持很小，`clone()` 几乎不花钱。昂贵的是不对称情形：快消费者冲在前面、慢的落后，或为某个后来证明不需要的目的创建了分支。
+
+## [Abort 比 promise 活得更久](#abort-outlives-the-promise)
+
+多数代码心里的模型是：`AbortSignal` 取消进行中的请求；promise 一旦 resolve，请求就结束了，没什么可取消。前半对，后半假定 promise resolve 等于交换结束——而这正是全文在拆的假定。
+
+在 headers 到达前 abort，结果熟悉。Promise reject，没有 `Response`，失败落在 `await` 所在之处。这个例子需要服务器扣住 headers，所以在 `writeHead` 前加 300ms 延迟，并在 50ms abort：
+
+```js
+import { createServer } from 'node:http'
+
+const server = createServer((_, res) => {
+  setTimeout(() => {
+    res.writeHead(200, { 'content-type': 'application/octet-stream' })
+    res.end(Buffer.alloc(60 * 1024 * 1024))
+  }, 300)
+})
+await new Promise((r) => server.listen(0, r))
+const url = `http://localhost:${server.address().port}/`
+
+const controller = new AbortController()
+setTimeout(() => controller.abort(), 50)
+await fetch(url, { signal: controller.signal })
+// DOMException [AbortError]: This operation was aborted
+```
+
+后面三个例子用同一服务器，去掉延迟，也就是上一节那版七行服务器。
+
+Promise 已经 resolve 之后再 abort，是另一种操作、另一种形状。`Response` 已经存在，谁也拿不走，于是 rejection 出现在下一次从 body 拉取时：
+
+```js
+const controller = new AbortController()
+const response = await fetch(url, { signal: controller.signal })
+const reader = response.body.getReader()
+const first = await reader.read()
+console.log('first chunk', first.value.byteLength)
+
+controller.abort()
+await reader.read()
+// DOMException [AbortError]: This operation was aborted
+```
+
+```
+first chunk 65356
+```
+
+第一块 chunk 已在手中且仍然有效。第二次 `read()` reject。服务端请求会发 `aborted`，响应以 `writableFinished` 为 false 关闭，所以这是真正的断开而不是客户端装样子：剩余字节永远不会发送——这正是你想要的结果，也是大下载半途 abort 值得做的原因。
+
+abort 之前到达的一切仍可读，从不属于 body 的一切也一样。Status 与 headers 是你已经持有的对象上的属性：
+
+```js
+const controller = new AbortController()
+const response = await fetch(url, { signal: controller.signal })
+controller.abort()
+console.log(response.status, response.headers.get('content-type'))
+// 200 application/octet-stream
+await response.arrayBuffer()
+// DOMException [AbortError]: The operation was aborted.
+```
+
+便捷方法无法交付部分结果，所以若 abort 落在完成前，`arrayBuffer`、`json`、`text` 会直接 reject。通过 `getReader()` 读取才能保留已到达的 chunk——部分 body 有用时这很重要，没用时则不然。
+
+Body 读到末尾后，`abort()` 什么也不做，也不抛错：
+
+```js
+const controller = new AbortController()
+const response = await fetch(url, { signal: controller.signal })
+const body = await response.arrayBuffer()
+controller.abort()
+console.log('read', body.byteLength, 'bytes, abort threw nothing')
+// read 62914560 bytes, abort threw nothing
+```
+
+没有错误可报，因为它本要取消的操作已经结束。这使得把 abort 留在 cleanup 路径里很安全，也很方便；同时也意味着调用成功并不能告诉你是否真的取消了什么。
+
+底下的协作模型见 [Cancellation In JavaScript](https://blog.gaborkoos.com/posts/2025-12-23-Cancellation-In-JavaScript-Why-Its-Harder-Than-It-Looks/)：signal 表达意图，操作决定如何兑现。`fetch` 额外的一点是：操作保持「可兑现」的时间，比 promise 暗示的更长。Promise settle 时 signal 并未耗尽，它会一直连着 body，直到最后一块 chunk 落地。
+
+## [只罩住半个请求的超时](#the-timeout-that-only-covered-half-the-request)
+
+把超时写成 `fetch` promise 与 `setTimeout` rejection 的 race，是把 deadline 罩在 promise 上的常见模式。既然 promise 在 headers 解析完就 settle，deadline 只罩住 header 阶段，body 开始到达的那一刻就不再适用。
+
+下面两台服务器其实是同一台，靠路径区分。`/slow-body` 立刻发 headers，然后每 10ms 写一块 64KB，共 80 块。`/slow-headers` 等 800ms 才 `writeHead`，然后只发一块。各自在一个阶段拖延、在另一阶段全速：
+
+```js
+import { createServer } from 'node:http'
+
+const CHUNK = 64 * 1024
+const server = createServer((req, res) => {
+  const delay = req.url === '/slow-headers' ? 800 : 0
+  setTimeout(() => {
+    res.writeHead(200, { 'content-type': 'application/octet-stream' })
+    if (delay) return res.end(Buffer.alloc(CHUNK))
+    let sent = 0
+    const tick = setInterval(() => {
+      res.write(Buffer.alloc(CHUNK))
+      if (++sent === 80) {
+        clearInterval(tick)
+        res.end()
+      }
+    }, 10)
+  }, delay)
+})
+await new Promise((r) => server.listen(0, r))
+const url = `http://localhost:${server.address().port}`
+
+const withTimeout = (promise, ms) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), ms)),
+  ])
+
+const t0 = performance.now()
+const response = await withTimeout(fetch(`${url}/slow-body`), 200)
+console.log('race settled at', (performance.now() - t0).toFixed(1))
+const body = await response.arrayBuffer()
+console.log('body', body.byteLength, 'bytes at', (performance.now() - t0).toFixed(1))
+
+server.close()
+process.exit(0)
+```
+
+```
+race settled at 59.7
+body 5242880 bytes at 1251.3
+```
+
+Race 在 59ms 结束并拿到 `Response`，定时器输掉，再也不会开火。200ms 预算在请求真正有趣的部分开始前就花光了，操作在 1251ms 结束，无人能拦。把同一段代码指向 `/slow-headers`，它会如宣传的那样在约 225.9ms 以 `timeout` reject，因为它守卫的阶段正是慢的那一段。两次运行代码完全一样，所以靠读代码很难抓到。
+
+`AbortSignal.timeout` 是传进请求，而不是跟 promise 赛跑；如前一节所示，只要 body 仍在到达，signal 就一直连着响应。因此预算耗尽时，它会在当时正在跑的那个阶段到期：
+
+```js
+for (const path of ['/slow-body', '/slow-headers']) {
+  const t0 = performance.now()
+  try {
+    const response = await fetch(`${url}${path}`, { signal: AbortSignal.timeout(200) })
+    const body = await response.arrayBuffer()
+    console.log(path, 'read', body.byteLength, 'at', (performance.now() - t0).toFixed(1))
+  } catch (error) {
+    console.log(path, error.name, 'at', (performance.now() - t0).toFixed(1))
+  }
+}
+```
+
+```
+/slow-body    TimeoutError at 203.2
+/slow-headers TimeoutError at 213.4
+```
+
+两种情况现在都在预算附近几毫秒内停下。慢 body 会在投递中途被切断——赛跑版做不到，因为那时它已经够不着请求了。
+
+若在浏览器里复现，请保持标签页在前台。Chrome 会把后台标签页的 `setTimeout` 钳到大约一秒，于是未聚焦标签里的 200ms 预算会在 800ms 之后才开火，本来正确的超时看起来像坏了。这组测量的第一次运行就因此作废。
+
+把预算与其他任何 signal 组合是另一个问题，因为请求通常有不止一个停止理由。我的 http 库 [ffetch](https://github.com/fetch-kit/ffetch) 会把调用方的 signal、request transform 可能引入的 signal、超时 signal，以及它自己用于取消的内部 controller 合成一个 signal，再把 `AbortSignal.any` 的结果传进 `fetch`。任何一个开火都会 abort 请求；又因为它是作为请求的 signal 传入，而不是绕在 promise 外，headers 到达之后它仍有效。
+
+## [读 body 才是真正的活](#reading-the-body-is-the-real-work)
+
+到目前为止的一切，都是同一事实从不同侧面推出来的后果：连接仍开着，因为 body 还没到。`clone()` 做 tee 而不是拷贝，因为 body 还没到。Promise resolve 之后 abort 仍能咬人，因为 body 还没到。赛跑超时错过慢场景，因为 body 还没到。
+
+正是这道缝，才让一组有用的事成为可能。`response.body` 是 `ReadableStream`，仍在被写入的 stream 可以在有人读远端之前先 pipe 过某层。边过边数字节是最直白的例子：
+
+```js
+import { createServer } from 'node:http'
+
+const CHUNK = 64 * 1024
+const server = createServer((_, res) => {
+  res.writeHead(200, {
+    'content-type': 'application/octet-stream',
+    'content-length': String(80 * CHUNK),
+  })
+  let sent = 0
+  const tick = setInterval(() => {
+    res.write(Buffer.alloc(CHUNK))
+    if (++sent === 80) {
+      clearInterval(tick)
+      res.end()
+    }
+  }, 10)
+})
+await new Promise((r) => server.listen(0, r))
+const url = `http://localhost:${server.address().port}/`
+
+const t0 = performance.now()
+const response = await fetch(url)
+console.log('promise settled at', (performance.now() - t0).toFixed(1))
+
+const total = Number(response.headers.get('content-length'))
+let transferred = 0
+
+const counted = new Response(
+  response.body.pipeThrough(
+    new TransformStream({
+      transform(chunk, controller) {
+        transferred += chunk.byteLength
+        const percent = Math.round((transferred / total) * 100)
+        if (percent % 25 === 0) {
+          console.log(percent, '% at', (performance.now() - t0).toFixed(1))
+        }
+        controller.enqueue(chunk)
+      },
+    })
+  ),
+  { status: response.status, headers: response.headers }
+)
+
+const body = await counted.arrayBuffer()
+console.log('read', body.byteLength, 'at', (performance.now() - t0).toFixed(1))
+
+server.close()
+process.exit(0)
+```
+
+```
+promise settled at 52.6
+25 % at 340.4
+50 % at 639.9
+75 % at 948.4
+100 % at 1257.6
+read 5242880 at 1262.3
+```
+
+Promise 在 52ms settle，进度行铺在随后的一千二百毫秒里。这些数字之所以存在，是因为 `await` 返回后仍有东西可观察。那时 `content-length` 也可读，百分比才成为可能：总量在 headers 里，累计值在 stream 里。
+
+包装与计数同等重要：`pipeThrough` 返回的是 stream 而不是 `Response`，所以要把变换后的 stream 连同原来的 status 与 headers 放进新的 `Response`，拿到它的人可以照常调用 `json()` 或 `arrayBuffer()`，不必知道中间发生过什么。这正是 ffetch 下载进度插件在 `src/plugins/download-progress.ts` 里的形状：`response.body` 为 null 时提早返回（`HEAD` 或 204 没什么可变换），防御性解析 `content-length`（服务器可能送来非数字），在 `transform` 里计数并原样 enqueue 每个 chunk，再围绕新 stream 重建 `Response`。能拦截响应并交回另一个响应的插件，只因为拦截发生在 payload 存在之前。
+
+所以该把 `await fetch(url)` 读成它本来的样子：headers 已完整、body 即将开始的那一点。那一行之后的任何东西，都不该当成请求的终点。连接、内存、取消与截止时间，都属于接下来的部分；你在 `await` 之后写的代码，才是决定那部分如何进行的代码。

--- a/archive/2026-09-12/mobile/An-early-look-at-Expo-Modules-2.0.md
+++ b/archive/2026-09-12/mobile/An-early-look-at-Expo-Modules-2.0.md
@@ -1,0 +1,210 @@
+---
+title: "Expo Modules 2.0 抢先看"
+title_en: "An early look at Expo Modules 2.0"
+source_url: https://expo.dev/blog/an-early-look-at-expo-modules-2-0
+author: Tomasz Sapeta
+published_at: 2026-09-08
+translated_at: 2026-09-12
+tech_domain: mobile
+tags: [mobile, expo, react-native, swift, modules]
+cover_image: https://cdn.sanity.io/images/9r24npb8/production/a8ef43c79f0c7cc757ef965b2afd75dbf09da0a9-2400x1350.png?w=1200&h=630&fit=crop&fm=webp&q=80&auto=format
+---
+
+# Expo Modules 2.0 抢先看
+
+原文链接：<https://expo.dev/blog/an-early-look-at-expo-modules-2-0>
+
+原文作者：Tomasz Sapeta
+
+![文章头图](https://cdn.sanity.io/images/9r24npb8/production/a8ef43c79f0c7cc757ef965b2afd75dbf09da0a9-2400x1350.png?w=1200&h=630&fit=crop&fm=webp&q=80&auto=format)
+
+作者：[Tomasz Sapeta](https://github.com/tsapeta)
+
+发布于 2026 年 9 月 8 日。
+
+**Expo Modules 2.0：用注解过的 Swift / Kotlin 类写原生模块；iOS 已可在 SDK 57 试用，SDK 58 进入 beta，并带来显著的调用性能提升。**
+
+给 React Native 写原生模块，马上会舒服很多、也快很多。到了 Expo Modules 2.0，模块就是一个带注解的 Swift 或 Kotlin 类：照常写方法和属性，给要对 JavaScript 暴露的那些打上标记，就完事了。除了一小撮注解，没什么新东西要学，也没有 boilerplate 要养，而且运行时比它替换掉的那套 API 更快。
+
+短版就是这样。Expo Modules API 一直在替你扛原生互操作的硬活：在 JavaScript 值与原生类型之间转换数据、把函数跑到正确的线程上好让设备核心被用上却不用你自己写同步，以及把模块接到应用生命周期。2.0 改的是你真正动笔的那部分。1.0 里，你用一套专用 DSL 描述模块向 JavaScript 暴露什么。2.0 里这些直接来自原生代码，做模块就像给普通 iOS / Android 应用写 Swift 或 Kotlin。
+
+Expo Modules 2.0 即将到来，iOS 上已经能试：SDK 57 带上了驱动它的 Swift macros，覆盖 modules、functions、records、shared objects 与 events。Views 还没覆盖（下文细说），Android 会跟同一套作者模型，仍在推进。到 SDK 58，Expo Modules 2.0 会进入 beta：有文档、正式、并附带一个教你的 coding assistant 新 API 的 agent skill。因为 iOS 先到，下面例子用 Swift。长这样。
+
+如果你读过 [Talking to JSI in Swift: what changed in SDK 56](https://expo.dev/blog/talking-to-jsi-in-swift)，这篇是续集，建立在那里描述的工作之上。iOS 上，SDK 56 处理的是模块底下那层：我们丢掉了 Objective-C++ shim，Swift 现在直接跟 JSI 说话，调用大约快一倍。Android 的地基是另一种形态——把部分工作从 runtime 挪到 build time 的 Kotlin compiler plugin，见 [How a Kotlin compiler plugin cut Android time to first render by 30%](https://expo.dev/blog/how-a-kotlin-compiler-plugin-cut-android-time-to-first-render)。这篇讲的是你在那层地基之上写的代码。
+
+下面是一个用 Expo Modules 1.0 API 写的小模块：
+
+```swift
+public final class MyModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("MyModule")
+    Function("add") { (a: Double, b: Double) in
+      return a + b
+    }
+    AsyncFunction("fetchValue") { (key: String) in
+      return try await store.read(key)
+    }
+    Property("ready") {
+      return self.isReady
+    }
+  }
+}
+```
+
+这能跑，Expo 生态里大量原生代码也是这么写的。但要写它，你脑子里（或 coding agent 的上下文里）得装不少东西。这套 DSL 是自己的小语法，建立在名为 result builders 的 Swift 特性上（SwiftUI 的 `body` 也是同一套机制）。你得认识它的词表：`Function`、`AsyncFunction`、`Property`、`Class`、`Events` 等等。你得写清闭包参数类型，并选 sync 还是 async 变体。这些都跟模块实际干什么无关。Expo Modules 2.0 把这些全拿掉，拥抱纯 Swift 语法。
+
+```swift
+@ExpoModule
+public final class MyModule {
+  @JS
+  func add(a: Double, b: Double) -> Double {
+    return a + b
+  }
+
+  @JS
+  func fetchValue(key: String) async throws -> String {
+    return try await store.read(key)
+  }
+
+  @JS
+  var ready: Bool {
+    return isReady
+  }
+}
+```
+
+这就是整个模块。带注解的方法和属性组成的类，别无其他：没有 `definition()`，没有 `Name(...)`（名字默认是类名，除非你在 macro 参数里传入），也没有 result builder。每个 DSL 部件都折进普通 Swift 声明。
+
+`Function` 与 `AsyncFunction` 都变成标了 `@JS` 的普通 Swift 方法。名字和类型直接从声明读取。是 sync 还是 async 由 Swift 的 `async` 关键字决定：`async` 方法在 JavaScript 里表现为返回 Promise 的函数。
+
+Expo Modules 1.0 里带 getter / setter 的 `Property`，现在就是一个 Swift `var`。可写的 Swift 属性（stored `var` 以及带 setter 的计算属性）在 JS 里也可写。只读 Swift 属性（`let` 常量与只有 getter 的 `var`）在 JS 里只读。这些属性从 Swift 和 JS 都能访问，不需要额外配置；在 Expo Modules 2.0 里，定义属性的 API 就是 Swift 语法本身。
+
+迁移不必一次做完。两套 API 可以共存在同一模块：保留现有 `definition()`，加上 `@ExpoModule`，再把 functions 与 properties 逐个挪到 `@JS`。还没有 2.0 形态的东西可以继续留在 definition 里。两者会合并，所以可以渐进采用，不用整模块重写。
+
+你甚至不必手改。`expo-migrate-module` skill 能让 coding agent 把模块的 Swift 侧从 1.0 迁到 2.0，并保持 JavaScript API 不变。它还迁不了的，会留在 1.0 的 `definition()` 并写进报告，你就清楚还剩什么。跑：
+
+```bash
+npx skills@latest use expo/skills@expo-migrate-module --agent claude-code
+```
+
+这会启动加载了该 skill 的交互会话；把 `claude-code` 换成 `codex`、`cursor` 或你用的任意 agent。skill 住在 `expo-experiments` 插件里，跟着 API 一起演进，`use` 每次都会拉最新版。
+
+变的不只是 functions。模块的其他积木也走同一思路：拥抱原生语法。
+
+Record 就是一个 Swift struct，每个不是 `private`、`static` 或 `lazy` 的 stored property 都会变成字段。字段是 required、optional 还是 nullable，从声明读取，没什么额外要写：
+
+```swift
+@Record
+struct Options {
+  var name: String
+  var count: Int = 0
+  var note: String?
+}
+```
+
+Shared object 是一个类，其实例同时存在于 Swift 与 JavaScript：JS 握着由原生实例 backing 的对象。暴露方式与模块相同，用 `@JS` 方法和属性，包括成为 JS constructor 的 `@JS init()`。
+
+```swift
+@SharedObject
+final class MediaPlayer: SharedObject {
+  private let player: AVPlayer
+
+  @JS
+  init(src: String) {
+    player = AVPlayer(url: URL(fileURLWithPath: src))
+  }
+
+  @JS
+  func play() {
+    player.play()
+  }
+
+  @JS
+  var currentTime: Double {
+    get {
+      return player.currentTime().seconds
+    }
+    set {
+      player.seek(to: CMTime(seconds: newValue, preferredTimescale: 600))
+    }
+  }
+
+  @JS
+  var muted: Bool {
+    get {
+      return player.isMuted
+    }
+    set {
+      player.isMuted = newValue
+    }
+  }
+}
+```
+
+JS 侧拿到偏 Web 风味的 API，`currentTime` 以秒计，像 HTML media 元素；类在底下把它映射到 AVFoundation 类型。JavaScript 看见的形状由你设计；注解只是把它带过去。
+
+在 1.0 里，event 是注册过的字符串名，外加 `sendEvent(...)` 调用：
+
+```swift
+public final class DownloadModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("DownloadModule")
+    Events("progress")
+  }
+
+  func tick() {
+    sendEvent("progress", ["percent": 50])
+  }
+}
+```
+
+到了 Expo Modules 2.0，event 是一个带类型的可调用属性。你声明一次 payload 类型，调用该属性就会派发事件：
+
+```swift
+@ExpoModule
+public final class DownloadModule {
+  @Event
+  var onProgress: (ProgressEvent) -> Void
+
+  func tick() {
+    onProgress(ProgressEvent(percent: 50))
+  }
+}
+
+@Record
+struct ProgressEvent {
+  var percent: Int
+}
+```
+
+Payload 可以是任何能送进 JavaScript 的类型：primitives、arrays、dictionaries、records、shared objects、typed arrays 与 array buffers，以及开箱即用的平台类型如 `Data` 和 `Date`。支持其他原生类型只需采纳 `JavaScriptEncodable` 与 `JavaScriptDecodable` 协议，就像采纳 Swift 自己的 `Codable`。若 payload 类型送不出去，Swift 编译器会在构建期给出清晰错误，尽量早发现，别等用户装上你的应用。
+
+「比以前更重要」说的是现在谁在写这些代码。原生模块越来越多是在 coding agent 参与下编写、审阅、迁移的，你交给那个 agent 的 API 决定了这个环有多顺。让 2.0 对你好用的一切（更少要学、类型在一处、错误落在出错处）也正是 coding model 需要的。
+
+模型在十多年的 Swift 与 Kotlin 上训练过，而 1.0 DSL 可供学习的例子相对很少，所以今天 agent 需要把 API 写进上下文窗口。到了 2.0，多数 API 就是语言本身，要学的少得多。而且 2.0 把 generate-error-fix 环压得很短：编译器能在模块声明里找出坏类型，并报告对 agent 友好的错误。能写 iOS 应用的 agent，也能写 Expo module。
+
+这也是 SDK 56 那摊工作开始兑现的地方，也是为什么 2.0 不只是更顺手的语法。
+
+Expo Modules 2.0 用构建期 macro（`@JS`）读取你的 Swift 函数签名，所以它提前知道每个参数与返回值的精确类型。1.0 要到 runtime 才知道，于是走反射那条路：每次原生调用都把传入参数包进已分配、引用计数的容器，再经动态类型转换塞进 `[Any]` 数组，拼出 tuple 才能调用你的函数。这条动态路径是今天单次调用上剩下的最大成本。函数签名提前已知后，生成的 bindings 就在 JS runtime 放好参数的地方直接读取，并转成对应的 Swift 参数，一路上不再额外分配。1.0 每次调用重复做的类型转换，在 2.0 里发生在构建期，runtime 的逐次记账也没了。
+
+性能提升很可观，要感谢横跨三个 SDK 的优化。SDK 56 去掉了 Objective-C++ 层，让 Expo Module 调用比 SDK 55 快 1.5 到 2 倍，并与 React Native 的 Turbo Modules 持平。SDK 57 再次改进共享 runtime，这一块让每个模块受益，包括仍留在 1.0 的。如图所示，它们一行代码没改也变快了。在此之上，`@JS` macro 清掉了剩余的动态逐次调用开销。
+
+这是 100,000 次调用的总时间，越低越好：
+
+![四项基准对比柱状图：iPhone 16 Pro、iOS 27、Release 构建，100,000 次调用总时间。Sync no-op：SDK 55 135 ms，SDK 56 80 ms，SDK 57 1.0 52 ms，SDK 57 2.0 9 ms，TurboModule 113 ms。两 double 相加：212、107、97、19、136 ms。字符串拼接：220、143、121、48、190 ms。Async no-op：1219、747、610、556、1080 ms。](https://cdn.sanity.io/images/9r24npb8/production/22b9bc3c445c7f1765dbf5bae442c03c7014f59f-2400x2622.jpg?auto=format&fit=max&q=75&w=800)
+
+全部数字测自同一套环境：iPhone 16 Pro，跑 iOS 27，Release 构建，预编译 frameworks。
+
+同一 SDK 上，同步调用的 `@JS` 路径比 1.0 API 快 2.5 到 5.6×。Async 调用彼此接近，因为两套 API 底下共用同一套 promise 机制。Async 更大的改进会落在 SDK 58。最干净的 API，现在也是调进模块最快的路径。
+
+Views 是下一步。它们会跟 modules 同一模型：view 是标了 `@ExpoView` 的类，props 与 event callbacks 一次声明在带类型的 `@ViewProps` struct 里，而不再拆散在原生 view 与手写 JS prop 类型之间。
+
+我们还在做的另一块是生成 TypeScript。因为每个 `@JS` 成员、`@Record` 与 view prop 已经在原生签名里带着类型，工具将能从该源生成模块的 TypeScript 声明。今天你要分别写原生类型与匹配的 TypeScript 声明；目标是只写一次。
+
+这跟另一些 React Native 模块的 codegen 方向相反——那里你写 TypeScript spec，生成器再搭好原生脚手架让你填。Expo Modules 2.0 里，你像任何原生应用一样直接用平台原生 API，应用其余部分留在 React，TypeScript 类型从原生代码长出来。模块的 TypeScript 声明变成生成的构建产物，CI 能发现它们是否与原生代码脱节。
+
+发出 TypeScript 声明的工具链，会先把 Swift 源转成机器可读的模块导出摘要：每个 function、property、record、event 及其类型。这份摘要也带来 spec-first 的好处：一旦 Android 能从 Kotlin 源产出同一摘要，工具链就能 diff 两者，在变成 JS bug 之前抓住无意的平台差异。
+
+> 🚀 今天，在 iOS 上，在 SDK 57。核心 macros（`@ExpoModule`、`@JS`、`@Record`、`@SharedObject`、`@Event`）已经随 SDK 发布。它们还没有文档，所以先当实验特性：API 仍可能变，指南与参考会跟 SDK 58 beta 一起落地。Android 支持在推进中。若你今天就想用这种方式写 iOS 模块，可以。
+
+更长远看，Expo Modules 2.0 会成为写 Expo module 的默认方式，而 1.0 继续支撑已经用它建成的一切。若你写原生模块，在 SDK 57 里试 2.0，并在 [Expo Developers Discord](https://chat.expo.dev/) 的 `#creating-expo-modules` 频道告诉我们什么好用、什么不好用、还想要什么。正式 beta 会在 SDK 58 到来。

--- a/archive/2026-09-12/mobile/React-Native-Navigation-Benchmarks.md
+++ b/archive/2026-09-12/mobile/React-Native-Navigation-Benchmarks.md
@@ -1,0 +1,86 @@
+---
+title: "React Native 导航现状"
+title_en: "React Native Navigation Benchmarks"
+source_url: https://andrei-calazans.com/posts/2026-06-05-state-of-rn-navigation/
+author: Andrei Calazans
+published_at: 2026-06-05
+translated_at: 2026-09-12
+tech_domain: mobile
+tags: [mobile, react-native, navigation, expo, performance]
+cover_image: https://andrei-calazans.com/og-image/2026-06-05-state-of-rn-navigation.png
+---
+
+# React Native 导航现状
+
+原文链接：<https://andrei-calazans.com/posts/2026-06-05-state-of-rn-navigation/>
+
+原文作者：Andrei Calazans
+
+![文章头图](https://andrei-calazans.com/og-image/2026-06-05-state-of-rn-navigation.png)
+
+作者：[Andrei Calazans](https://andrei-calazans.com)
+
+发布于 2026 年 6 月 5 日。
+
+**同一套 UI 用四大导航库各做一遍：冷启动差近 3 倍，FPS 都接近 60——差距主要在启动成本与内存。**
+
+我想弄清楚怎么把 React Native 应用做到尽可能快。其中一块就是搞懂导航的代价——它在启动时跑，每次切屏也跑，而多数团队选库时并不知道真实数字。
+
+于是我把同一应用做了四遍——每个主流导航库一遍——并量了所有东西：冷启动、RAM、FPS，以及 JS 线程实际在干什么。下面是结果。
+
+**为什么是 Android？** 生产环境里 React Native 的性能瓶颈最常在 Android 上冒出来，而且它能给出最丰富的 profiling 数据。Perfetto Systrace 能以微秒级分辨率抓住每条线程边界——UI 线程、JS 线程、RenderThread、SurfaceFlinger。Hermes CPU sampler 则给出整段启动突发的 source-mapped JS 调用栈。合在一起，才能回答 *为什么*，而不只是 *有多慢*。iOS 也有对等工具，但数据颗粒度更粗。这里全部只测 Android。
+
+> **环境：** Expo SDK 56 · RN 0.85 · Hermes · New Architecture（bridgeless / Fabric）· Samsung Galaxy A16 · Android 14 · release/profileable 构建。冷启动 = OS `Displayed` 指标；FPS / CPU / RAM 来自 [Flashlight](https://github.com/bamlab/flashlight) 驱动 [Maestro](https://maestro.mobile.dev/)；拆解来自 Perfetto Systrace + source-mapped Hermes CPU profile。全部数据与工具见 [StateOfReactNativeNavigation 仓库](https://github.com/AndreiCalazans/StateOfReactNativeNavigation)。
+
+每个应用都从共享 UI 包渲染相同屏幕——30 行列表、push 到 Details、切换 tab。唯一变量是导航库。
+
+## [头条数字](#the-headline-numbers)
+
+对比库：react-native-navigation（Wix）、React Navigation v7、Navigation（Graham Mendick）、Expo Router。
+
+| Library | Cold start (ms) | Avg FPS | Avg CPU % | Peak RAM (MB) |
+| --- | --- | --- | --- | --- |
+| react-native-navigation | 316 | 59.8 | 31.2 | 195 |
+| React Navigation v7 | 358 | 59.9 | 37.8 | 214 |
+| Navigation | 398 | 59.8 | 34.8 | 241 |
+| Expo Router | 917 | 59.8 | 37.1 | 308 |
+
+冷启动 = 3 次运行中位数；RAM = Flashlight 在 navigate flow 上的峰值。四者都稳住约 60 FPS——差异在 **启动成本** 与 **内存**。
+
+冷启动 — OS `Displayed`（越低越好）
+
+| 库 | 冷启动 |
+| --- | --- |
+| rn-navigation | 316 ms |
+| React Navigation | 358 ms |
+| Navigation | 398 ms |
+| Expo Router | 917 ms |
+
+[视频：rn-navigation vs Expo Router 冷启动](https://andrei-calazans.com/videos/cold-rnn-vs-expo-router.mp4)
+
+两极：**react-native-navigation**（约 316 ms）已经停在 Home 并可交互，而 **Expo Router**（约 917 ms）还在撑着 splash——大约晚整整一秒落地。
+
+[视频：React Navigation vs Navigation 冷启动](https://andrei-calazans.com/videos/cold-react-navigation-vs-navigation.mp4)
+
+中间档：**React Navigation v7**（约 358 ms）与 **Navigation** router（约 398 ms）彼此只差一两帧。
+
+## [三件让我意外的事](#three-things-that-surprised-me)
+
+**Expo Router 冷启动大约是 3 倍——但主因不是 Reanimated。** Expo Router 模板自带 `react-native-reanimated@4` 与 `react-native-worklets`，其他三套没有。受控实验显示 Reanimated 只给冷启动加了约 62 ms。大头差距来自大约 2× 更大的 bundle，以及叠在 React Navigation 之上的 router 层：启动时要评估 106 个 JS module，其他库只有 36–43 个。
+
+**真正的 RAM 故事是 Reanimated。** 只在最瘦的应用（rn-navigation）上加 Reanimated，就能复现 Expo Router 的全部 RAM 溢价：+125 MB，几乎全是 Worklets 拉起的第二个 Hermes runtime 带来的 anonymous heap。[Bundle mode 本应修好这点](https://andrei-calazans.com/posts/2026-07-15-which-react-native-animation-library/#update-reanimated-worklets-bundle-mode)，但它其实会[拖慢冷启动，因为必须解析整份 bundle](https://github.com/software-mansion/react-native-reanimated/issues/10437)。
+
+**rn-navigation 赢在导航是原生的。** 它的 JS bundle 评估只要 55 ms。tabs 与 stack 是 Kotlin view——启动时 JS 线程几乎不怎么跑。React Navigation 的 JS bundle 要 168 ms，因为它要搭一棵由 Fabric reconcile 的真实组件树。但也不全是鲜花：rn-navigation 这套做法也会[在大屏上喘不过气、掉很多帧](https://andrei-calazans.com/posts/2026-06-07-the-cost-of-navigating/#heavy-screen-what-changes-with-real-content)。
+
+## [系列文章](#the-series)
+
+* [Deep Diving Where Time Is Spent](https://andrei-calazans.com/posts/2026-06-06-react-native-navigation-cold-start/) — 为什么 Expo Router 慢、React Navigation 在 rn-navigation 之上多加了什么、各库的 Hermes 热点函数，以及 Reanimated 受控实验。
+* [What’s the Expo Tax?](https://andrei-calazans.com/posts/2026-06-07-the-cost-of-expo/) — 接入 Expo 的固定成本（约 36 ms、约 13 MB RAM、约 16 MB APK），以及每多一个 Expo module 的边际成本。
+* [What Does Navigating to a Screen Cost?](https://andrei-calazans.com/posts/2026-06-07-the-cost-of-navigating/) — 从按下到绘制，在平凡屏与重屏上的成本、各库 JS 调用栈，以及当屏幕真有活干时「首帧」意味着什么。
+
+## [免责声明](#caveats)
+
+* **rn-navigation 是裸 RN 应用；另外三套是 Expo 应用。** 它的一部分领先来自「没有 expo-modules-core」，不只是导航库本身。RNN 自己拥有 React host，这与 Expo 的 host factory 不兼容。
+* **一台设备、一套简单 UI。** Samsung Galaxy A16、Android 14、Hermes、New Architecture。更重的屏幕会改写 FPS 与导航成本故事。
+* **数字仅供参考。** Hermes sampling 较粗；冷启动中位数是 3 次运行，且始终开着 profiling 插桩（会同等抬高所有应用的绝对时间）。
+* **Expo Router 为这份成本换来更多能力。** Deep linking、懒加载屏幕、基于文件的路由、Web 支持。这些数字量的是平凡应用上的启动——不是对这些功能值不值得的最终判决。

--- a/docs/keep-english-terms.md
+++ b/docs/keep-english-terms.md
@@ -93,6 +93,9 @@
 | PlatformColor | RN 颜色 API |
 | Upgrade Helper | 社区升级工具名 |
 | hermesc / hermes-engine | Hermes 工具链 |
+| Expo Modules / Expo Modules 2.0 | Expo 原生模块 API |
+| `@ExpoModule` / `@JS` / `@Record` / `@SharedObject` / `@Event` | Expo Modules 2.0 Swift macros |
+| Flashlight / Maestro / Perfetto | 性能测量工具 |
 
 ## Web / CSS / 前端
 
@@ -122,6 +125,9 @@
 | DOM / HTML / SVG / SMIL | |
 | Shadow DOM / Custom Elements | |
 | Playwright / Puppeteer | |
+| AbortSignal / AbortController | Fetch 取消 API |
+| ReadableStream / TransformStream | Web Streams |
+| ffetch | fetch-kit 库名 |
 | Testing Library / Jest / Vitest | |
 
 ## AI / 智能体


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 翻译 [React Native Navigation Benchmarks](https://andrei-calazans.com/posts/2026-06-05-state-of-rn-navigation/)
- 翻译 [An early look at Expo Modules 2.0](https://expo.dev/blog/an-early-look-at-expo-modules-2-0)
- 翻译 [Half Past Fetch](https://blog.gaborkoos.com/posts/2026-09-08-Half-Past-Fetch/)
- 更新 README 与 `docs/keep-english-terms.md`

Closes #305

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e066dd5-a148-426a-a52d-5362db362bf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e066dd5-a148-426a-a52d-5362db362bf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

